### PR TITLE
Issue 177 - Truncate title to 60 char

### DIFF
--- a/js/models/itemMd.js
+++ b/js/models/itemMd.js
@@ -165,6 +165,9 @@ module.exports = window.Backbone.Model.extend({
           "returns": ""
         };
       }
+      if(response.vendor_offer.listing.item.title.length > 60){
+        response.vendor_offer.listing.item.truncated_title = response.vendor_offer.listing.item.title.substring(0,60);
+      }
       //make sure image hashes are valid
       response.vendor_offer.listing.item.image_hashes = response.vendor_offer.listing.item.image_hashes.filter(function(hash){
         return hash !== "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb" && hash.length === 40;

--- a/js/templates/item.html
+++ b/js/templates/item.html
@@ -1,6 +1,6 @@
 <div class="flexRow custCol-border-secondary">
   <div class="flexRow bar barTxt pad20 textOpacity75">
-    <a class="js-returnToStore textOpacity1">All Items</a>&nbsp;>&nbsp;<%- ob.vendor_offer.listing.item.title %>
+    <a class="js-returnToStore textOpacity1">All Items</a>&nbsp;>&nbsp;<%- ob.vendor_offer.listing.item.truncated_title || ob.vendor_offer.listing.item.title %>
   </div>
 </div>
 <div class="flexRow border0">
@@ -17,7 +17,10 @@
 </div>
 <div class="flexCol-7 pad20Right">
   <div class="row20 rowTop20 clearfix">
-    <h1 class="page-contractTitle"><%- ob.vendor_offer.listing.item.title %></h1>
+    <h1 class="page-contractTitle"><%- ob.vendor_offer.listing.item.truncated_title || ob.vendor_offer.listing.item.title %>
+     <% if(ob.vendor_offer.listing.item.truncated_title) { %>
+        <a class="textOpacity1 js-viewFullTitle">...</a>
+      <% } %></h1>
     <p class="margin0 marginTop2 textOpacity75 fontSize14">
       <%- ob.displayPrice %> (<%- ob.vendorBTCPrice %> btc) 
       <% if(ob.vendor_offer.listing.item.condition) { %>

--- a/js/templates/itemEdit.html
+++ b/js/templates/itemEdit.html
@@ -1,6 +1,6 @@
 <div class="flexRow custCol-border-secondary">
   <div class="flexRow bar barTxt pad20">
-    <a class="js-returnToStore textOpacity75"><%= polyglot.t('All') %> <%= polyglot.t('Items') %></a><span class="textOpacity75">&nbsp;>&nbsp;<%- ob.vendor_offer.listing.item.title %></span>
+    <a class="js-returnToStore textOpacity75"><%= polyglot.t('All') %> <%= polyglot.t('Items') %></a><span class="textOpacity75" title='<%- ob.vendor_offer.listing.item.title %>'>&nbsp;>&nbsp;<%- ob.vendor_offer.listing.item.truncated_title || ob.vendor_offer.listing.item.title %></span>
   </div>
 </div>
 

--- a/js/views/itemVw.js
+++ b/js/views/itemVw.js
@@ -10,7 +10,8 @@ module.exports = Backbone.View.extend({
     'click .js-descriptionTab': 'descriptionClick',
     'click .js-reviewsTab': 'reviewsClick',
     'click .js-shippingTab': 'shippingClick',
-    'click .js-buyButton': 'buyClick'
+    'click .js-buyButton': 'buyClick',
+    'click .js-viewFullTitle': 'viewFullTitle'
   },
 
   initialize: function(){
@@ -34,6 +35,10 @@ module.exports = Backbone.View.extend({
 
   descriptionClick: function(e){
     this.tabClick($(e.target).closest('.js-tab'), this.$el.find('.js-description'));
+  },
+
+  viewFullTitle: function(e){
+    $(e.target).closest('.page-contractTitle').html(this.model.get('vendor_offer').listing.item.title);
   },
 
   reviewsClick: function(e){


### PR DESCRIPTION
Issue 177 - Truncate title to 60 char for Items, and allow for expansion.  Always show truncated title if available in breadcrumb bar.
