### PR TITLE
Long title fix

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -353,6 +353,7 @@ form {
 .table {
   display: table;
   table-layout: fixed;
+  width: 100%;
 }
 
 .table > div {
@@ -650,6 +651,12 @@ h5 {
 
 .allCaps {
   text-transform: uppercase;
+}
+
+.noOverflow {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 /*========== skin classes ==========*/
 

--- a/css/obBase.css
+++ b/css/obBase.css
@@ -2455,6 +2455,10 @@ input[type="checkbox"].fieldItem + label span {
   box-sizing: border-box;
 }
 
+#ov1 .width75px {
+  width: 75px;
+}
+
 #ov1 .width600 {
   width: 600px;
 }

--- a/js/templates/item.html
+++ b/js/templates/item.html
@@ -1,6 +1,15 @@
 <div class="flexRow custCol-border-secondary">
   <div class="flexRow bar barTxt pad20 textOpacity75">
-    <a class="js-returnToStore textOpacity1">All Items</a>&nbsp;>&nbsp;<%- ob.vendor_offer.listing.item.title %>
+    <div class="table">
+      <div>
+        <div class="width75px">
+          <a class="js-returnToStore textOpacity1">All Items</a>&nbsp;>&nbsp;
+        </div>
+        <div class="noOverflow">
+          <%- ob.vendor_offer.listing.item.title %>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 <div class="flexRow border0">
@@ -17,7 +26,7 @@
 </div>
 <div class="flexCol-7 pad20Right">
   <div class="row20 rowTop20 clearfix">
-    <h1 class="page-contractTitle"><%- ob.vendor_offer.listing.item.title %></h1>
+    <h1 class="page-contractTitle noOverflow" title="<%- ob.vendor_offer.listing.item.title %>"><%- ob.vendor_offer.listing.item.title %></h1>
     <p class="margin0 marginTop2 textOpacity75 fontSize14">
       <%- ob.displayPrice %> (<%- ob.vendorBTCPrice %> btc) 
       <% if(ob.vendor_offer.listing.item.condition) { %>

--- a/js/templates/itemShort.html
+++ b/js/templates/itemShort.html
@@ -4,14 +4,12 @@
   </div>
   <div class="table">
     <div>
-      <div>
-        <% if(ob.showAvatar) { %>
-        <div class="thumbnail js-avatar" data-handle="<%- ob.handle %>"
-          style="background-image: url(<%- ob.avatarURL %>), url(imgs/defaultUser.png);"></div>
-        <% } %> 
-      </div>
+      <% if(ob.showAvatar) { %>
+      <div class="thumbnail js-avatar" data-handle="<%- ob.handle %>"
+        style="background-image: url(<%- ob.avatarURL %>), url(imgs/defaultUser.png);"></div>
+      <% } %>
       <div class="js-item pad8Left" data-id="<%- ob.contract_hash %>">
-        <div class="textSize14px textFirstCharUppercase"><%- ob.title %></div>
+        <div class="textSize14px textFirstCharUppercase noOverflow"><%- ob.title %></div>
         <div class="textSize13px txt-fade textWeightNormal"><%- ob.displayPrice %> (<%- ob.vendorBTCPrice %> btc)</div>
       </div>
     </div>

--- a/js/templates/itemShort.html
+++ b/js/templates/itemShort.html
@@ -9,7 +9,7 @@
         style="background-image: url(<%- ob.avatarURL %>), url(imgs/defaultUser.png);"></div>
       <% } %>
       <div class="js-item pad8Left" data-id="<%- ob.contract_hash %>">
-        <div class="textSize14px textFirstCharUppercase noOverflow"><%- ob.title %></div>
+        <div class="textSize14px textFirstCharUppercase noOverflow" title="<%- ob.title %>"><%- ob.title %></div>
         <div class="textSize13px txt-fade textWeightNormal"><%- ob.displayPrice %> (<%- ob.vendorBTCPrice %> btc)</div>
       </div>
     </div>

--- a/js/templates/userPage.html
+++ b/js/templates/userPage.html
@@ -40,21 +40,20 @@
   </div>
 
   <div class="flexRow shadow-inner1 user-page-header">
-    <!--<form id="userPageImageForm">
-      <label for="userPageImageUpload" class="btn btn-c1 btn-txt rowTop20 fullCentered js-itemCustomizationButtons"><%= polyglot.t('UploadCoverPhoto') %> (959px x 400px)</label>
-      <input type="file" name="image" id="userPageImageUpload" accept="image/*" class="hide js-userPageImageUpload">
-    </form>-->
-    <!-- This wraps the whole cropper -->
-    <div class="rowItem positionAbsolute bottom0 width600" style="padding: 0 20px">
-      <div class="thumbnail thumbnail-large pull-left js-userPageAvatar"
-           style="background-image: url(<%- ob.user.server_url %>get_image?hash=<%- ob.page.profile.avatar_hash %>), url(imgs/defaultUser.png);"></div>
-    <div class="pull-left">
-      <div class="marginLeft12 push-down5">
-        <h1 class="page-userNameLarge"><%- ob.page.profile.name %></h1>
-        <div class="textSize16px"><%- ob.page.profile.handle %></div>
+    <div class="rowItem positionAbsolute bottom0 width600 pad20">
+      <div class="table">
+        <div>
+          <div class="thumbnail thumbnail-large js-userPageAvatar"
+               style="background-image: url(<%- ob.user.server_url %>get_image?hash=<%- ob.page.profile.avatar_hash %>), url(imgs/defaultUser.png);">
+          </div>
+          <div class="pad15 push-down5 noOverflow">
+            <span class="h1 page-userNameLarge"><%- ob.page.profile.name %></span>
+            <br />
+            <span class="textSize16px"><%- ob.page.profile.handle %></span>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
   </div>
 
   <div class="bar user-page-navigation-filler hidden custCol-primary" style="display: none"></div>

--- a/js/templates/userShort.html
+++ b/js/templates/userShort.html
@@ -1,19 +1,23 @@
 <div class="rowItem js-userShort clickable padding2015" data-guid="<%= ob.guid %>">
-  <div class="thumbnail pull-left custCol-border-secondary"
-  style="background-image: url(<%- ob.avatarURL %>), url(imgs/defaultUser.png);"></div>
-  <div class="pull-left txt-unleaded">
-    <div class="marginLeft10 marginTop2 clearfix">
-      <div class="textSize14px marginRight5 marginBottom2"><%- ob.name %></div>
-      <div class="textSize14px txt-fade textWeightNormal">
-        <% if(ob.handle) { %>
-          <%- ob.handle %>
-        <% }else{ %>
-          <%- ob.guid %>
-        <% } %>
+  <div class="table">
+    <div>
+      <div class="thumbnail custCol-border-secondary"
+                     style="background-image: url(<%- ob.avatarURL %>), url(imgs/defaultUser.png);"></div>
+      <div class="txt-unleaded">
+        <div class="marginLeft10 marginTop2 clearfix">
+          <div class="textSize14px marginRight5 marginBottom2 noOverflow" title="<%- ob.name %>"><%- ob.name %></div>
+          <div class="textSize14px txt-fade textWeightNormal">
+            <% if(ob.handle) { %>
+            <%- ob.handle %>
+            <% }else{ %>
+            <%- ob.guid %>
+            <% } %>
+          </div>
+        </div>
+        <div class="marginLeft10">
+          <div class="testSize15px txt-fade"><%- ob.short_description %></div>
+        </div>
       </div>
-    </div>
-    <div class="marginLeft10">
-      <div class="testSize15px txt-fade"><%- ob.short_description %></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds a noOverflow class, which uses the text-overflow: ellipses CSS property to truncate long titles. 

This only works on containers with constrained sizes, and the text being truncated must be in an inline element, not a block element.
