### PR TITLE
Extend bt cdigits

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -51,7 +51,9 @@ input::-webkit-input-placeholder,
 input[type="text"]::-webkit-input-placeholder,
 input[type="number"]::-webkit-input-placeholder,
 select::-webkit-input-placeholder,
-textarea::-webkit-input-placeholder{
+textarea::-webkit-input-placeholder,
+.txt-placeholder,
+.fieldItem .txt-placeholder {
   opacity: .5;
   color: #fff;
   font-size: 14px;

--- a/js/models/itemMd.js
+++ b/js/models/itemMd.js
@@ -201,9 +201,9 @@ module.exports = window.Backbone.Model.extend({
     if(userCCode) {
       getBTPrice(vendorCCode, function(btAve){
         vendorCurrencyToBitcoinRatio = btAve;
-        vendorPriceInBitCoin = Number(vendorPrice / btAve).toFixed(6);
-        vendorDomesticShippingInBitCoin = Number(vendorDomesticShipping / btAve).toFixed(6);
-        vendorInternationalShippingInBitCoin = Number(vendorInternationalShipping / btAve).toFixed(6);
+        vendorPriceInBitCoin = Number(vendorPrice / btAve).toFixed(4);
+        vendorDomesticShippingInBitCoin = Number(vendorDomesticShipping / btAve).toFixed(4);
+        vendorInternationalShippingInBitCoin = Number(vendorInternationalShipping / btAve).toFixed(4);
         vendToUserBTCRatio = window.currentBitcoin/vendorCurrencyToBitcoinRatio;
         newAttributes.vendorBTCPrice = vendorPriceInBitCoin;
 

--- a/js/models/itemMd.js
+++ b/js/models/itemMd.js
@@ -201,9 +201,9 @@ module.exports = window.Backbone.Model.extend({
     if(userCCode) {
       getBTPrice(vendorCCode, function(btAve){
         vendorCurrencyToBitcoinRatio = btAve;
-        vendorPriceInBitCoin = Number((vendorPrice / btAve).toFixed(4));
-        vendorDomesticShippingInBitCoin = Number((vendorDomesticShipping / btAve.toFixed(4)));
-        vendorInternationalShippingInBitCoin = Number((vendorInternationalShipping / btAve.toFixed(4)));
+        vendorPriceInBitCoin = Number(vendorPrice / btAve).toFixed(6);
+        vendorDomesticShippingInBitCoin = Number(vendorDomesticShipping / btAve).toFixed(6);
+        vendorInternationalShippingInBitCoin = Number(vendorInternationalShipping / btAve).toFixed(6);
         vendToUserBTCRatio = window.currentBitcoin/vendorCurrencyToBitcoinRatio;
         newAttributes.vendorBTCPrice = vendorPriceInBitCoin;
 

--- a/js/models/itemShortMd.js
+++ b/js/models/itemShortMd.js
@@ -40,7 +40,7 @@ module.exports = Backbone.Model.extend({
     if(userCCode) {
       getBTPrice(vendorCCode, function(btAve){
         vendorCurrencyInBitcoin = btAve;
-        vendorBitCoinPrice = Number(vendorPrice / btAve).toFixed(6);
+        vendorBitCoinPrice = Number(vendorPrice / btAve).toFixed(4);
         vendToUserBTCRatio = window.currentBitcoin/vendorCurrencyInBitcoin;
         newAttributes.vendorBTCPrice = vendorBitCoinPrice;
 

--- a/js/models/itemShortMd.js
+++ b/js/models/itemShortMd.js
@@ -40,7 +40,7 @@ module.exports = Backbone.Model.extend({
     if(userCCode) {
       getBTPrice(vendorCCode, function(btAve){
         vendorCurrencyInBitcoin = btAve;
-        vendorBitCoinPrice = Number((vendorPrice / btAve).toFixed(4));
+        vendorBitCoinPrice = Number(vendorPrice / btAve).toFixed(6);
         vendToUserBTCRatio = window.currentBitcoin/vendorCurrencyInBitcoin;
         newAttributes.vendorBTCPrice = vendorBitCoinPrice;
 

--- a/js/models/userMd.js
+++ b/js/models/userMd.js
@@ -36,6 +36,9 @@ module.exports = Backbone.Model.extend({
   parse: function(response) {
     "use strict";
 
+    //make sure currency code is in all caps
+    response.currency_code = response.currency_code.toUpperCase();
+
     //find the human readable name for the country
     var matchedCountry = this.countryArray.filter(function(value, i){
       return value.dataName == response.country;

--- a/js/templates/itemEdit.html
+++ b/js/templates/itemEdit.html
@@ -94,13 +94,13 @@
               <input type="text" name="currency_code" id="inputCurrencyCode" class="hide" />
               <input type="number" name="priceLocal" step="any" class="fieldItem js-priceLocal custCol-text"  id="priceLocal" value="<%- ob.price %>" required
                 <% if(ob.userCurrencyCode == "BTC"){ %>
-                min="0.001"
+                min="0.0001"
                 <% } else { %>
                 min="0.01"<% } %>
               >
             </div>
             <div class="flexCol-4">
-              <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.001<% } %></span>
+              <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.0001<% } %></span>
             </div>
           </div>
           <div class="flexRow custCol-border-secondary js-shippingRow">
@@ -200,13 +200,13 @@
                 <input type="text" name="shipping_currency_code" id="inputShippingCurrencyCode" class="hide" />
                 <input type="number" step="any" class="fieldItem js-priceLocal custCol-text" id="shippingPriceLocalLocal"  value="<%- ob.domesticShipping %>"
                   <% if(ob.userCurrencyCode == "BTC"){ %>
-                  min="0.001"
+                  min="0.0001"
                   <% } else { %>
                   min="0.01"<% } %>
                 >
               </div>
               <div class="flexCol-4">
-                <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.001<% } %></span>
+                <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.0001<% } %></span>
               </div>
             </div>
             <div class="flexRow custCol-border-secondary js-inputParent js-shippingPriceRow">
@@ -219,13 +219,13 @@
                 <input type="text" name="shipping_international" id="inputShippingInternational" class="hide" />
                 <input type="number" step="any" class="fieldItem js-priceLocal custCol-text" id="shippingPriceInternationalLocal" value="<%- ob.internationalShipping %>"
                   <% if(ob.userCurrencyCode == "BTC"){ %>
-                  min="0.001"
+                  min="0.0001"
                   <% } else { %>
                   min="0.01"<% } %>
                 >
               </div>
               <div class="flexCol-4">
-                <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.001<% } %></span>
+                <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.0001<% } %></span>
               </div>
             </div>
             <div class="flexRow custCol-border-secondary js-shippingRow">

--- a/js/templates/itemEdit.html
+++ b/js/templates/itemEdit.html
@@ -92,7 +92,15 @@
             <div class="flexCol-5">
               <input type="number" step="any" name="price" id="inputPrice" class="hide" />
               <input type="text" name="currency_code" id="inputCurrencyCode" class="hide" />
-              <input type="number" name="priceLocal" step="any" min="0.01" class="fieldItem js-priceLocal custCol-text"  id="priceLocal" value="<%- ob.price %>" required>
+              <input type="number" name="priceLocal" step="any" class="fieldItem js-priceLocal custCol-text"  id="priceLocal" value="<%- ob.price %>" required
+                <% if(ob.userCurrencyCode == "BTC"){ %>
+                min="0.001"
+                <% } else { %>
+                min="0.01"<% } %>
+              >
+            </div>
+            <div class="flexCol-4">
+              <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.001<% } %></span>
             </div>
           </div>
           <div class="flexRow custCol-border-secondary js-shippingRow">
@@ -190,7 +198,15 @@
               <div class="flexCol-4">
                 <input type="text" name="shipping_domestic" id="inputShippingDomestic" class="hide" />
                 <input type="text" name="shipping_currency_code" id="inputShippingCurrencyCode" class="hide" />
-                <input type="number" step="any" min="0.01" class="fieldItem js-priceLocal custCol-text" id="shippingPriceLocalLocal"  value="<%- ob.domesticShipping %>">
+                <input type="number" step="any" class="fieldItem js-priceLocal custCol-text" id="shippingPriceLocalLocal"  value="<%- ob.domesticShipping %>"
+                  <% if(ob.userCurrencyCode == "BTC"){ %>
+                  min="0.001"
+                  <% } else { %>
+                  min="0.01"<% } %>
+                >
+              </div>
+              <div class="flexCol-4">
+                <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.001<% } %></span>
               </div>
             </div>
             <div class="flexRow custCol-border-secondary js-inputParent js-shippingPriceRow">
@@ -201,7 +217,15 @@
               </div>
               <div class="flexCol-4">
                 <input type="text" name="shipping_international" id="inputShippingInternational" class="hide" />
-                <input type="number" step="any" min="0.01" class="fieldItem js-priceLocal custCol-text" id="shippingPriceInternationalLocal" value="<%- ob.internationalShipping %>">
+                <input type="number" step="any" class="fieldItem js-priceLocal custCol-text" id="shippingPriceInternationalLocal" value="<%- ob.internationalShipping %>"
+                  <% if(ob.userCurrencyCode == "BTC"){ %>
+                  min="0.001"
+                  <% } else { %>
+                  min="0.01"<% } %>
+                >
+              </div>
+              <div class="flexCol-4">
+                <span class="fieldItem txt-placeholder"><% if(ob.userCurrencyCode == "BTC"){ %>Minimum is 0.001<% } %></span>
               </div>
             </div>
             <div class="flexRow custCol-border-secondary js-shippingRow">

--- a/js/views/adminPanelVw.js
+++ b/js/views/adminPanelVw.js
@@ -274,23 +274,23 @@ module.exports = Backbone.View.extend({
         newAddresses.push(self.model.get('shipping_addresses')[$(this).val()]);
       });
 
-    formData.append('shipping_addresses', JSON.stringify(newAddresses));
-    existingKeys.shipping_addresses = newAddresses;
+    if(newAddresses){
+      formData.append('shipping_addresses', JSON.stringify(newAddresses));
+      existingKeys.shipping_addresses = newAddresses;
+      }
 
     formData.append('currency_code', this.$el.find('#adminCurrencyInput').val());
 
     formData = this.modelToFormData(this.userSettings.toJSON(), formData, existingKeys);
 
-    if(targetForm[0].checkValidity()){
-      this.postData(formData, "settings",
-          function (data) {
-            self.updatePage();
-          },
-          function (data) {
-            alert("Failed. " + data.reason);
-          }
-      );
-    }
+    this.postData(formData, "settings",
+        function (data) {
+          self.updatePage();
+        },
+        function (data) {
+          alert("Failed. " + data.reason);
+        }
+    );
   },
 
   modelToFormData: function(modelJSON, formData, existingKeys) {


### PR DESCRIPTION
- changes minimum price and shipping on items for sale to 0.0001 if the user has their currency set to Bitcoin
- changes the display of BTC prices to have 4 decimals everywhere
- post-placeholder text in item edit to explain minimum if price is in BTC
- math when rounding to 4 digits is done slightly more accurately
