### PR TITLE
Simple tooltips

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -2796,3 +2796,14 @@ input[type="checkbox"].fieldItem + label span {
     background-color: #B22222;
   /* don't put a border on this or it will be visible when it has no content */
 }
+
+.tooltip {
+    position: absolute;
+    z-index: 10;
+    background-color: rgba(45,45,45,0.9);
+    padding: 4px 6px;
+    pointer-events: none;
+    border: 1px solid rgba(55, 55, 55, 0.6);
+    border-radius: 3px;
+    color: #f7f7f7;
+}

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -16,10 +16,10 @@
   </div>
 </div>
 <div class="ctrlGroup">
-  <a class="btn btn-home ion-eye custCol-primary fontSize15" href="#home"></a>
+  <a class="btn btn-home ion-eye custCol-primary fontSize15" href="#home" simple-tooltip="Discover"></a>
 </div>
 <div class="ctrlGroup">
-  <div class="btn btn-notifications ion-android-notifications custCol-primary fontSize14 js-navNotifications badge"></div>
+  <div class="btn btn-notifications ion-android-notifications custCol-primary fontSize14 js-navNotifications badge" simple-tooltip="Notifications"></div>
 </div>
 <div class="popMenu popMenu-notifications hide js-navNotificationsMenu">
     <div class="popMenu-notificationsHeader"><%= polyglot.t('nav.notifications') %></div>
@@ -30,7 +30,7 @@
 </div>
 
 <div class="ctrlGroup nav-profile">
-  <div class="btn btn-profile js-navProfile custCol-primary"
+  <div class="btn btn-profile js-navProfile custCol-primary" simple-tooltip="Menu"
   <% if(ob.avatar_hash != "") { %>
   style="background-image: url(<%- ob.serverUrl %>get_image?hash=<%- ob.avatar_hash %>), url(imgs/defaultUser.png);"
   <% }else{ %>

--- a/js/utils/tooltip.js
+++ b/js/utils/tooltip.js
@@ -1,0 +1,38 @@
+var $ = require('jquery');
+
+var tooltipEl = document.createElement('div');
+tooltipEl.className = 'tooltip';
+
+function getTargetInfo(el) {
+    var space = 4;
+    var offset = $(el).offset();
+    var rect = el.getBoundingClientRect();
+    var elMidX = offset.left + rect.width / 2;
+    var elMidY = offset.top + rect.height / 2;
+    var showBelow = elMidY < window.innerHeight / 2;
+    return {
+        showBelow: showBelow,
+        x: elMidX,
+        y: showBelow ? offset.top + rect.height + space : offset.top - space
+    };
+}
+
+module.exports = {
+  show: function(evt) {
+    var simpleTooltip = evt.target.getAttribute('simple-tooltip');
+    if (simpleTooltip) {
+        tooltipEl.textContent = simpleTooltip;
+        document.body.appendChild(tooltipEl);
+        var rect = tooltipEl.getBoundingClientRect();
+        var target = getTargetInfo(evt.target);
+        var offsetY = target.showBelow ? 0 : -rect.height;
+        tooltipEl.style.left = Math.min(window.innerWidth - 5, Math.max(5, target.x - rect.width / 2));
+        tooltipEl.style.top = target.y + offsetY;
+    }
+  },
+  hide: function(evt) {
+    if (evt.target.getAttribute('simple-tooltip')) {
+        document.body.removeChild(tooltipEl);
+    }
+  }
+};

--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -9,7 +9,8 @@ var __ = require('underscore'),
     languageListView = require('../views/languageListVw'),
     adminPanelView = require('../views/adminPanelVw'),
     notificationsPanelView = require('../views/notificationsPanelVw'),
-    remote = require('remote');
+    remote = require('remote'),
+    tooltip = require('../utils/tooltip');
 
 module.exports = Backbone.View.extend({
 
@@ -38,7 +39,10 @@ module.exports = Backbone.View.extend({
     'click .js-closeModal': 'closeModal',
     'keyup .js-navAddressBar': 'addressBarKeyup',
     'click .js-closeStatus': 'closeStatusBar',
-    'click .js-homeModal-themeSelected': 'setSelectedTheme'
+    'click .js-homeModal-themeSelected': 'setSelectedTheme',
+    'mouseover [simple-tooltip]': tooltip.show,
+    'mouseout [simple-tooltip]': tooltip.hide,
+    'click [simple-tooltip]': tooltip.hide
   },
 
   initialize: function(options){


### PR DESCRIPTION
#215. Basic tooltip feature using an attribute. May not cover all use-cases (for example if the tooltip needs more than just text, or needs custom positioning/behaviour).

Not sure how to do the event handling globally with Backbone so the events would need to be added to any view that uses the attribute.

![tooltip](https://cloud.githubusercontent.com/assets/960919/11207306/6d6de596-8d0c-11e5-8ad9-99b97fa0cebd.png)

pre-commit task failed but not sure if this is a known issue - #221 
