### PR TITLE
Limit Currencies to Those Supported by Price Average APIs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -101,11 +101,20 @@ var loadProfile = function() {
             cCode = model.get('currency_code');
 
             //get user bitcoin price before loading pages
-            getBTPrice(cCode, function (btAve) {
+            getBTPrice(cCode, function (btAve, currencyList) {
               //put the current bitcoin price in the window so it doesn't have to be passed to models
+              if(!btAve){
+                currencyList = currencyList.join("\n");
+                alert("Bitcoin prices for your selected currency are not available. Your currency has been set to BTC. " +
+                    "You can change this in the settings console. \n\n The following currencies are available: \n\n" + currencyList);
+                window.currentBitcoin = 1;
+                user.set('currency_code', 'BTC');
+                cCode = "BTC";
+              }
               window.currentBitcoin = btAve;
+
               //every 15 minutes update the bitcoin price
-              setTimeout(function () {
+              window.bitCoinPriceChecker = setInterval(function () {
                 getBTPrice(cCode, function (btAve) {
                   window.currentBitcoin = btAve;
                 });

--- a/js/templates/userPage.html
+++ b/js/templates/userPage.html
@@ -70,7 +70,7 @@
 
   <div class="bar user-page-navigation-filler hidden custCol-primary" style="display: none"></div>
   <div class="bar navBar barFlush user-page-navigation custCol-secondary">
-    <a class="btn btn-bar btn-tab custCol-secondary active js-aboutTab js-tab"><%= polyglot.t('About') %></a>
+    <a class="btn btn-bar btn-tab custCol-secondary js-aboutTab js-tab"><%= polyglot.t('About') %></a>
     <a class="btn btn-bar btn-tab custCol-secondary js-followersTab js-tab"><%= polyglot.t('Followers') %></a>
     <a class="btn btn-bar btn-tab custCol-secondary js-followingTab js-tab"><%= polyglot.t('Following') %></a>
     <% if(ob.page.profile.vendor) { %>
@@ -151,8 +151,8 @@
       </div>
     </div>
   </div>
-  <div class="userPage-subViews">
-    <div class="flexContainer flex-border custCol-primary js-about js-tabTarg minHeight650">
+  <div class="userPage-subViews custCol-primary minHeight650">
+    <div class="flexContainer flex-border custCol-primary hide js-about js-tabTarg minHeight650">
       <div class="flexRow minHeight650">
         <div class="flexCol-8 custCol-border-secondary">
           <div class="rowItem">

--- a/js/utils/getBitcoinPrice.js
+++ b/js/utils/getBitcoinPrice.js
@@ -22,7 +22,7 @@ module.exports = function (currency, callback) {
             })
                 .done(function (response) {
                     var BlockchainCurrencies = {};
-                    for (var bcCurrency in response) {  //TODO: Use _.forOwn
+                    for (var bcCurrency in response) {
                         if (response.hasOwnProperty(bcCurrency)) {
                             BlockchainCurrencies[bcCurrency] = response[bcCurrency]['15m'];
                         }
@@ -44,7 +44,7 @@ module.exports = function (currency, callback) {
             })
                 .done(function (response) {
                     var CoinkiteCurrencies = {};
-                    for (var ckCurrency in response.rates.BTC) {  //TODO: Use _.forOwn
+                    for (var ckCurrency in response.rates.BTC) {
                         if (response.rates.BTC.hasOwnProperty(ckCurrency)) {
                             CoinkiteCurrencies[ckCurrency] = response.rates.BTC[ckCurrency].rate;
                         }
@@ -67,7 +67,7 @@ module.exports = function (currency, callback) {
             })
                 .done(function (response) {
                     var BitcoinAvgCurrencies = {};
-                    for (var bcaCurrency in response) {  //TODO: Use _.forOwn ??
+                    for (var bcaCurrency in response) {
                         if (response[bcaCurrency].averages) {
                             BitcoinAvgCurrencies[bcaCurrency] = response[bcaCurrency].averages['24h_avg'];
                         }
@@ -90,7 +90,7 @@ module.exports = function (currency, callback) {
                 .done(function (response) {
                     response = JSON.parse(response);
                     var BitcoinChartsCurrencies = {};
-                    for (var bccCurrency in response) {  //TODO: Use _.forOwn
+                    for (var bccCurrency in response) {
                         if (response.hasOwnProperty(bccCurrency)) {
                             BitcoinChartsCurrencies[bccCurrency] = response[bccCurrency]['24h'];
                         }
@@ -112,9 +112,15 @@ module.exports = function (currency, callback) {
         }
 
         var makeAveragePrice = function () {
-            var sum, currencyPrices, currency_code, currencyKeys, averagePrice, keys = {}, btAve;
+            var sum,
+                currencyPrices,
+                currency_code,
+                currencyKeys,
+                averagePrice,
+                keys = {},
+                btAve;
             btcAverages.timeStamp = new Date();
-            for (var i in btPrices) { //TODO: Use _.forOwn
+            for (var i in btPrices) {
                 if (btPrices.hasOwnProperty(i)) {
                     keys = $.extend(keys, btPrices[i]);
                 }
@@ -123,17 +129,17 @@ module.exports = function (currency, callback) {
                 alert("Bitcoin exchange rates are not available.");
             }
             currencyKeys = Object.keys(keys);
-            for (var index in currencyKeys) {  //TODO: Use _.forOwn
+            for (var index in currencyKeys) {
                 if (currencyKeys.hasOwnProperty(index)) {
                     currency_code = currencyKeys[index];
                     currencyPrices = [];
-                    for (var j in btPrices) {  //TODO: Use _.forOwn or _.each?
+                    for (var j in btPrices) {
                         if (btPrices[j][currency_code]) {
                             currencyPrices.push(btPrices[j][currency_code]);
                         }
                     }
                     sum = 0;
-                    for (var jIndex in currencyPrices) {  //TODO: Use _.forOwn
+                    for (var jIndex in currencyPrices) {
                         if (currencyPrices.hasOwnProperty(jIndex)) {
                             sum += Number(currencyPrices[jIndex]);
                         }
@@ -144,7 +150,7 @@ module.exports = function (currency, callback) {
             }
             window.btcAverages = btcAverages;
             btAve = btcAverages.rates[currency];
-            typeof callback === 'function' && callback(btAve);
+            typeof callback === 'function' && callback(btAve, currencyKeys);
         };
 
     } else {

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -340,6 +340,9 @@ module.exports = Backbone.View.extend({
         addressState,
         currentHandle = this.model.get('page').profile.handle;
 
+    //clear old templates
+    this.$el.find('.js-list4').html("");
+
     if(state === "item"){
       this.renderItem(hash);
       $('#obContainer').scrollTop(367);
@@ -805,8 +808,8 @@ module.exports = Backbone.View.extend({
 
   saveNewDone: function(newHash) {
     "use strict";
-    this.subRender();
     this.setState('item', newHash);
+    this.subRender();
   },
 
   deleteOldDone: function(newHash) {


### PR DESCRIPTION
- on client start, the selected currency is checked. If the bitcoin average is not returned, an alert is shown and the user's currency is set to BTC.
- in settings, when selecting a currency, only currencies that are currently being returned from at least one bitcoin average API are shown as options
- if a user's currency stops being returned by the bitcoin average APIs while the client is in use, the next time a price check is done at the 15 minute mark they will be notified and their currency will be switched to BTC.
