### PR TITLE
refactor store wizard

### DIFF
--- a/js/models/userMd.js
+++ b/js/models/userMd.js
@@ -50,15 +50,18 @@ module.exports = Backbone.Model.extend({
 
     //addresses come from the server as a string. Parse the string
     response.shipping_addresses = response.shipping_addresses || [];
-    try{
-      var shipAddr = JSON.parse(response.shipping_addresses[0]);
-      if(shipAddr && typeof shipAddr === "object" && shipAddr !== null){
-        response.shipping_addresses = shipAddr;
+    if(response.shipping_addresses){
+      try{
+        var shipAddr = JSON.parse(response.shipping_addresses[0]);
+        if (shipAddr && typeof shipAddr === "object" && shipAddr !== null){
+          response.shipping_addresses = shipAddr;
+        }
       }
-    }
-    catch(e){
-      //server may set a malformed shipping_address value
-      console.log(e);
+      catch (e){
+        //server may set a malformed shipping_address value
+        console.log("Error in shipping_addresses:")
+        console.log(e);
+      }
     }
 
     return response;

--- a/js/templates/item.html
+++ b/js/templates/item.html
@@ -78,8 +78,14 @@
             <p><%= polyglot.t('EstimatedDelivery') %> (<%= polyglot.t('international') %>): <%- ob.vendor_offer.listing.shipping.est_delivery.international %></p>
             <hr/>
           <% } %>
-          <h3><%= polyglot.t('ReturnsPolicy') %></h3>
-          <p><%- ob.vendor_offer.listing.policy.returns %></p>
+          <% if(ob.vendor_offer.listing.policy.returns) { %>
+            <h3><%= polyglot.t('ReturnsPolicy') %></h3>
+            <p><%- ob.vendor_offer.listing.policy.returns %></p>
+          <% } %>
+          <% if(ob.vendor_offer.listing.policy.terms_conditions) { %>
+            <h3><%= polyglot.t('TermsAndConditions') %></h3>
+            <p><%- ob.vendor_offer.listing.policy.terms_conditions %></p>
+          <% } %>
         </div>
       </div>
     </div>

--- a/js/utils/saveToAPI.js
+++ b/js/utils/saveToAPI.js
@@ -1,0 +1,98 @@
+var __ = require('underscore'),
+    Backbone = require('backbone'),
+    $ = require('jquery'),
+    showErrorModal = require('../utils/showErrorModal.js');
+
+
+module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData) {
+  "use strict";
+  var self = this,
+      formData = new FormData(form[0] || ""),
+      formKeys = [],
+      tempDisabledFields = [];
+
+  if(form){
+    form.addClass('formChecked');
+    if (!form[0].checkValidity()){
+      showErrorModal(window.polyglot.t('errorMessages.saveError'), window.polyglot.t('errorMessages.missingError'));
+      return;
+    }
+
+    //temporarily disable any blank fields so they aren't picked up by the serializeArray
+    form.find(":input:not(:disabled)").each(function(){
+      if($(this).val() == "") {
+        $(this).attr('disabled', true);
+        tempDisabledFields.push($(this).attr('id'));
+      }
+    });
+
+    __.each(form.serializeArray(), function (value) {
+      formKeys.push(value.name);
+    });
+  }
+
+  //add manual data not in the form
+  __.each(addData, function(value, key){
+    console.log("foo");
+    console.log("add "+ key);
+    formKeys.push(value.name);
+    if(value.constructor === Array){
+      console.log("array");
+      __.each(value, function(val){
+        formData.append(key, val);
+      });
+    }else{
+      formData.append(key, value);
+      console.log(key);
+      console.log(value);
+    }
+  });
+
+  //add addresses in correct format or they will be destroyed by the server
+  if(endPoint == "settings" && modelJSON){
+    formKeys.push("shipping_addresses");
+    formData.append("shipping_addresses", JSON.stringify(modelJSON.shipping_addresses));
+  }
+
+  //if key is not in formKeys, get value from the model
+  if(modelJSON){
+    __.each(modelJSON, function (value, key) {
+      if (formKeys.indexOf(key) == -1){
+        formData.append(key, value);
+      }
+    });
+  }
+
+  $.ajax({
+    type: "POST",
+    url: endPoint,
+    contentType: false,
+    processData: false,
+    data: formData,
+    dataType: "json",
+    success: function(data) {
+      if (data.success === true){
+        onSucceed(data);
+      }else if (data.success === false){
+        if(onFail){
+          onFail(data);
+        } else{
+          showErrorModal(window.polyglot.t('errorMessages.saveError'), "<i>" + data.reason + "</i>");
+        }
+      } else {
+        showErrorModal(window.polyglot.t('errorMessages.saveError'), "<i>" + window.polyglot.t('errorMessages.serverError') + "</i>");
+      }
+    },
+    error: function(jqXHR, status, errorThrown){
+      console.log(jqXHR);
+      console.log(status);
+      console.log(errorThrown);
+    },
+    complete: function(){
+      //re-enable any disabled fields
+      __.each(tempDisabledFields, function(element){
+        form.find('#'+element).attr('disabled', false);
+      });
+    }
+  });
+}

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -577,7 +577,7 @@ module.exports = Backbone.View.extend({
       modList.push($(this).data('guid'));
     });
 
-    storeData.moderator_list = modList;
+    storeData.moderator_list = modList.length > 0 ? modList : "";
     storeData.vendor = true;
 
     this.saveData(form, "", "profile", function(){

--- a/js/views/storeWizardVw.js
+++ b/js/views/storeWizardVw.js
@@ -7,6 +7,7 @@ var __ = require('underscore'),
     colpicker = require('../utils/colpick.js'),
     countriesModel = require('../models/countriesMd'),
     showErrorModal = require('../utils/showErrorModal.js'),
+    saveToAPI = require('../utils/saveToAPI'),
     Taggle = require('taggle'),
     chosen = require('../utils/chosen.jquery.min.js');
 
@@ -143,6 +144,36 @@ module.exports = Backbone.View.extend({
   },
 
   saveWizard: function() {
+    "use strict";
+    var self = this,
+        profileForm = this.$el.find('#storeWizardForm'),
+        moderatorsChecked = $('.js-storeWizardModeratorList input:checked'),
+        userProfile = this.model.get('page').profile,
+        modList = [],
+        wizData = {};
+
+    //convert taggle tags to data in the form
+    this.$el.find('#realCategoriesInput').val(this.categoriesInput.getTagValues().join(","));
+
+    wizData.vendor = true;
+
+    moderatorsChecked.each(function() {
+      modList.push($(this).data('guid'));
+    });
+
+    wizData.moderator_list = modList.length > 0 ? modList : "";
+
+    wizData.primary_color = parseInt(userProfile.primary_color.slice(1), 16);
+    wizData.secondary_color = parseInt(userProfile.secondary_color.slice(1), 16);
+    wizData.background_color = parseInt(userProfile.background_color.slice(1), 16);
+    wizData.text_color = parseInt(userProfile.text_color.slice(1), 16);
+
+    saveToAPI(profileForm, this.model.get('page').profile, self.model.get('user').serverUrl + "profile", function(){
+      self.trigger('storeCreated');
+    }, "", wizData);
+  },
+
+  saveWizardOld: function() {
     "use strict";
     var self = this,
         profileForm = this.$el.find('#storeWizardForm'),


### PR DESCRIPTION
- adds a saveToAPI module that centralizes saving data and pulling missing data from the appropriate model
- switches store wizard view to the new module so name is not required to be in the form
- closes #118 return showing when it is empty on item screen
- adds terms and conditions to item screen
- fixes settings and store wizard bug where selecting zero moderators did not clear the moderator list
