### PR TITLE
Add button to clear local storage

### DIFF
--- a/js/templates/adminPanel.html
+++ b/js/templates/adminPanel.html
@@ -32,6 +32,29 @@
       </form>
     </div>
 
+    <h3>Clear Local Storage</h3>
+    <div class="box-border row20">
+      <form id="adminPanelServer">
+        <div class="flex-border">
+          <div class="flexRow">
+            <div class="flexCol-4">
+              <div class="fieldItem">
+                <p class="txt-unleaded">This will reset your server to the default local server, clear any saved image hashes, and reset your onboarding status.</p>
+              </div>
+              <div class="fieldItem">
+                <p class="txt-unleaded js-adminClearLocalMsg"></p>
+              </div>
+            </div>
+            <div class="flexCol-8">
+              <div class="rowTop20 pad20">
+                <a class="btn btn-txt row20 js-adminClearLocalStorage pull-right">Clear Local Storage</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+
     <h3>Set Moderator Status</h3>
     <div class="box-border row20">
       <form id="adminPanelModerator">

--- a/js/views/adminPanelVw.js
+++ b/js/views/adminPanelVw.js
@@ -22,7 +22,8 @@ module.exports = Backbone.View.extend({
     'blur input': 'validateInput',
     'blur textarea': 'validateInput',
     'click .js-adminShutdown': 'shutdown',
-    'click .js-adminCloseApp': 'closeApp'
+    'click .js-adminCloseApp': 'closeApp',
+    'click .js-adminClearLocalStorage': 'clearStorage'
   },
 
   initialize: function (options) {
@@ -242,6 +243,12 @@ module.exports = Backbone.View.extend({
     } else {
       win.hide();
     }
+  },
+
+  clearStorage: function(){
+    "use strict";
+    this.$el.find('.js-adminClearLocalMsg').text("Local Storage Cleared");
+    localStorage.clear();
   },
 
   close: function(){


### PR DESCRIPTION
This adds a button to the admin panel that will clear local storage. This is mainly for testing purposes, it will clear the values for your server, reset your onboarding status (so you can run onboarding again), and remove any stores avatar hashes.
