### PR TITLE
Changed placeholder text for processing time to reduce confusion

### DIFF
--- a/js/models/languagesMd.js
+++ b/js/models/languagesMd.js
@@ -62,7 +62,7 @@ module.exports = Backbone.Model.extend({
         SearchForUsersPlaceholder: "Search by handle or GUID",
         EstDeliveryDomesticPlaceholder: "3-5 Business Days",
         EstDeliveryInternationalPlaceholder: "7-15 Business Days",
-        OrderProcessingTimePlaceholder: "1-2 Business Days",
+        OrderProcessingTimePlaceholder: "Enter time needed to process order",
         TermsAndConditionsPlaceholder: "Enter terms and conditions...",
         TitlePlaceholder: "Enter title",
         DescriptionPlaceholder: "Enter description...",


### PR DESCRIPTION
Changed placeholder text for processing time field in new listings to reduce confusion. From "1-2 Business Days" to a prompt, "Enter time needed to process order"
