### PR TITLE
Save State and Bug Fixes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -37,12 +37,9 @@ var Polyglot = require('node-polyglot'),
     userProfile = new userProfileModel(),
     languages = new languagesModel(),
     socketView = require('./views/socketVw'),
-    guid = "",
-    avatar_hash = "",
     cCode = "",
     serverUrlLocal = "",
     loadProfileCount = 1,
-    loadProfileTimeout,
     loadProfileCountdownInterval,
     loadProfileCountdown = 5;
 
@@ -65,6 +62,12 @@ window.polyglot.extend(__.where(languages.get('languages'), {langCode: window.la
 
 //put the event bus into the window so it's available everywhere
 window.obEventBus =  __.extend({}, Backbone.Events);
+
+//record changes to the app state
+$(window).bind('hashchange', function(){
+  "use strict";
+  localStorage.setItem('route', Backbone.history.getFragment());
+});
 
 var setCurrentBitCoin = function(cCode, userModel, callback) {
   "use strict";
@@ -130,25 +133,22 @@ var loadProfile = function() {
       clearInterval(loadProfileCountdownInterval);
       //make sure profile is not blank
       if (response.profile){
-        //guid = response.profile.guid;
-        //avatar_hash = response.profile.avatar_hash;
         setTheme(model.get('profile').primary_color, model.get('profile').secondary_color, model.get('profile').background_color, model.get('profile').text_color);
         //get the user
         user.fetch({
           success: function (model, response) {
             user.set('serverUrl', serverUrlLocal);
-            //user.set('guid', guid);
-            //user.set('avatar_hash', avatar_hash);
             cCode = model.get('currency_code');
 
             //get user bitcoin price before loading pages
-            setCurrentBitCoin(cCode, user, function(){
+            setCurrentBitCoin(cCode, user, function() {
               $('.js-loadingMessageModal').addClass('hide');
               newSocketView = new socketView({model: user});
               newPageNavView = new pageNavView({model: user, socketView: newSocketView, userProfile: userProfile});
               newChatAppView = new chatAppView({model: user, socketView: newSocketView});
               newRouter = new router({userModel: user, userProfile: userProfile, socketView: newSocketView, chatAppView: newChatAppView});
               Backbone.history.start();
+
             });
 
             //every 15 minutes update the bitcoin price for the currently selected currency

--- a/js/models/userMd.js
+++ b/js/models/userMd.js
@@ -56,17 +56,19 @@ module.exports = Backbone.Model.extend({
     response.displayCountry = matchedCountry[0] ? matchedCountry[0].name : "";
 
     //addresses come from the server as a string. Parse the string
-    response.shipping_addresses = response.shipping_addresses || [];
-
-    if(response.shipping_addresses.constructor === Array && response.shipping_addresses.length > 0){
+    if(response.shipping_addresses && response.shipping_addresses.constructor === Array && response.shipping_addresses.length > 0){
       var tempAddresses = [];
       __.each(response.shipping_addresses, function(address){
-        address = JSON.parse(address);
-        if(address.name && address.street && address.city && address.state && address.postal_code && address.country && address.displayCountry){
-          tempAddresses.push(address);
+        if(address){
+          address = JSON.parse(address);
+          if(address.name && address.street && address.city && address.state && address.postal_code && address.country && address.displayCountry){
+            tempAddresses.push(address);
+          }
         }
       });
       response.shipping_addresses = tempAddresses;
+    } else {
+      response.shipping_addresses = [];
     }
 
     //set the client language to match the language in the response

--- a/js/models/userMd.js
+++ b/js/models/userMd.js
@@ -57,11 +57,27 @@ module.exports = Backbone.Model.extend({
 
     //addresses come from the server as a string. Parse the string
     response.shipping_addresses = response.shipping_addresses || [];
-    if(response.shipping_addresses){
+
+    console.log(response.shipping_addresses[0]);
+    console.log(typeof response.shipping_addresses[0]);
+    var test = response.shipping_addresses[0].split(",");
+    console.log(test);
+    __.each(test, function(val){
+      console.log(val);
+      console.log(typeof val);
+      console.log(val[0]);
+    });
+    if(response.shipping_addresses.length > 0){
       try{
         var shipAddr = JSON.parse(response.shipping_addresses[0]);
         if (shipAddr && typeof shipAddr === "object" && shipAddr !== null){
-          response.shipping_addresses = shipAddr;
+          //remove addresses with missing data
+          response.shipping_addresses = [];
+          __.each(shipAddr, function(address){
+            if(address.name && address.street && address.city && address.state && address.postal_code && address.country && address.displayCountry){
+              response.shipping_addresses.push(address);
+            }
+          });
         }
       }
       catch (e){

--- a/js/models/userMd.js
+++ b/js/models/userMd.js
@@ -58,34 +58,15 @@ module.exports = Backbone.Model.extend({
     //addresses come from the server as a string. Parse the string
     response.shipping_addresses = response.shipping_addresses || [];
 
-    console.log(response.shipping_addresses[0]);
-    console.log(typeof response.shipping_addresses[0]);
-    var test = response.shipping_addresses[0].split(",");
-    console.log(test);
-    __.each(test, function(val){
-      console.log(val);
-      console.log(typeof val);
-      console.log(val[0]);
-    });
-    if(response.shipping_addresses.length > 0){
-      try{
-        var shipAddr = JSON.parse(response.shipping_addresses[0]);
-        if (shipAddr && typeof shipAddr === "object" && shipAddr !== null){
-          //remove addresses with missing data
-          response.shipping_addresses = [];
-          __.each(shipAddr, function(address){
-            if(address.name && address.street && address.city && address.state && address.postal_code && address.country && address.displayCountry){
-              response.shipping_addresses.push(address);
-            }
-          });
+    if(response.shipping_addresses.constructor === Array && response.shipping_addresses.length > 0){
+      var tempAddresses = [];
+      __.each(response.shipping_addresses, function(address){
+        address = JSON.parse(address);
+        if(address.name && address.street && address.city && address.state && address.postal_code && address.country && address.displayCountry){
+          tempAddresses.push(address);
         }
-      }
-      catch (e){
-        //server may set a malformed shipping_address value
-        console.log("Error in shipping_addresses:");
-        console.log(e);
-        response.shipping_addresses = [];
-      }
+      });
+      response.shipping_addresses = tempAddresses;
     }
 
     //set the client language to match the language in the response

--- a/js/models/userProfileMd.js
+++ b/js/models/userProfileMd.js
@@ -7,7 +7,7 @@ module.exports = Backbone.Model.extend({
     profile: {
       guid: "",
       vendor: false,
-      name: "Default Name",
+      name: "",
       categories: ["category 1", "category 2"],
       moderator: false,
       moderators: ["moderator 1", "moderator 2"],
@@ -87,6 +87,12 @@ module.exports = Backbone.Model.extend({
       //check to make sure header hash is valid
       if(response.profile.header_hash === "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb" || response.profile.header_hash.length !== 40) {
         response.profile.header_hash = "";
+      }
+
+      if(!response.profile.avatar_hash && !response.profile.name && !response.profile.header_hash && !response.profile.handle){
+        response.profile.beenSet = false;
+      } else {
+        response.profile.beenSet = true;
       }
 
       //if name comes back blank, set to random value

--- a/js/router.js
+++ b/js/router.js
@@ -60,7 +60,9 @@ module.exports = Backbone.Router.extend({
 
   index: function(){
     "use strict";
-    if(this.userModel.get('beenSet') === true){
+    if(localStorage.getItem("route")){
+      this.navigate('#' + localStorage.getItem("route"), {trigger: true});
+    } else if(this.userProfile.get('profile').beenSet == true){
       this.home();
     } else {
       this.userPage();

--- a/js/templates/buyWizard.html
+++ b/js/templates/buyWizard.html
@@ -76,8 +76,11 @@
                   <label for="buyWizardNoModerator">
                     <div class="table">
                       <div>
-                        <div class="thumbnail thumbnail-large-slim box-border"
-                             style="background-image: url(<%- ob.serverUrl %>get_image?hash=<%- ob.avatar_hash %><%- ob.imageExtension %>), url(imgs/defaultItem.png);">
+                        <div class="thumbnail thumbnail-large-slim box-border" style="background-image:
+                        <% if(ob.avatar_hash) { %>
+                        url(<%- ob.serverUrl %>get_image?hash=<%- ob.avatar_hash %><%- ob.imageExtension %>),
+                        <% } %>
+                        url(imgs/defaultItem.png);">
                         </div>
                         <div class="pad10left txt-unleaded">
                           <div class="row10"><strong>Direct</strong></div>

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -537,8 +537,8 @@
                   <div>
                     <input type="range" class="cropit-image-zoom-input rowTop10 row10 width100" />
                   </div>
-                  <input type="file" id="settingsAvatarInput" class="cropit-image-input hide" />
-                  <label for="settingsAvatarInput" class="btn btn-txt btn-c1 btn-wide rowTop10 row20"><%= polyglot.t('UploadAvatar') %></label>
+                  <input type="file" id="onboardingAvatarInput" class="cropit-image-input hide" />
+                  <label for="onboardingAvatarInput" class="btn btn-txt btn-c1 btn-wide rowTop10 row20"><%= polyglot.t('UploadAvatar') %></label>
                 </div>
               </div>
             </div>

--- a/js/templates/settings.html
+++ b/js/templates/settings.html
@@ -817,8 +817,7 @@
                        id="settingsShipToName"
                        type="text"
                        placeholder="<%= polyglot.t('Name') %>"
-                       class="fieldItem settingsAddressInput"
-                       required >
+                       class="fieldItem settingsAddressInput">
               </div>
 
             </div>
@@ -838,8 +837,7 @@
                        id="settingsShipToStreet"
                        type="text"
                        placeholder="<%= polyglot.t('Street') %>"
-                       class="fieldItem settingsAddressInput"
-                       required >
+                       class="fieldItem settingsAddressInput">
               </div>
 
             </div>
@@ -859,8 +857,7 @@
                        id="settingsShipToCity"
                        type="text"
                        placeholder="<%= polyglot.t('City') %>"
-                       class="fieldItem settingsAddressInput"
-                       required >
+                       class="fieldItem settingsAddressInput">
               </div>
 
             </div>
@@ -880,8 +877,7 @@
                        id="settingsShipToState"
                        type="text"
                        placeholder="<%= polyglot.t('State') %>"
-                       class="fieldItem settingsAddressInput"
-                       required >
+                       class="fieldItem settingsAddressInput">
               </div>
 
             </div>
@@ -901,8 +897,7 @@
                        id="settingsShipToPostalCode"
                        type="text"
                        placeholder="<%= polyglot.t('PostalCode') %>"
-                       class="fieldItem settingsAddressInput"
-                       required >
+                       class="fieldItem settingsAddressInput">
               </div>
 
             </div>

--- a/js/templates/settings.html
+++ b/js/templates/settings.html
@@ -817,7 +817,8 @@
                        id="settingsShipToName"
                        type="text"
                        placeholder="<%= polyglot.t('Name') %>"
-                       class="fieldItem settingsAddressInput">
+                       class="fieldItem settingsAddressInput"
+                       required >
               </div>
 
             </div>
@@ -837,7 +838,8 @@
                        id="settingsShipToStreet"
                        type="text"
                        placeholder="<%= polyglot.t('Street') %>"
-                       class="fieldItem settingsAddressInput">
+                       class="fieldItem settingsAddressInput"
+                       required >
               </div>
 
             </div>
@@ -857,7 +859,8 @@
                        id="settingsShipToCity"
                        type="text"
                        placeholder="<%= polyglot.t('City') %>"
-                       class="fieldItem settingsAddressInput">
+                       class="fieldItem settingsAddressInput"
+                       required >
               </div>
 
             </div>
@@ -877,7 +880,8 @@
                        id="settingsShipToState"
                        type="text"
                        placeholder="<%= polyglot.t('State') %>"
-                       class="fieldItem settingsAddressInput">
+                       class="fieldItem settingsAddressInput"
+                       required >
               </div>
 
             </div>
@@ -897,7 +901,8 @@
                        id="settingsShipToPostalCode"
                        type="text"
                        placeholder="<%= polyglot.t('PostalCode') %>"
-                       class="fieldItem settingsAddressInput">
+                       class="fieldItem settingsAddressInput"
+                       required >
               </div>
 
             </div>

--- a/js/templates/settings.html
+++ b/js/templates/settings.html
@@ -226,12 +226,13 @@
               </div>
 
               <div class="flexCol-9 custCol-border-secondary">
-                <input name="short_description"
-                       type="text"
-                       id="short_description"
-                       placeholder="<%= polyglot.t('onboarding.ShortDescriptionPlaceholder') %>"
-                       class="fieldItem"
-                       value="<%= ob.page.profile.about %>">
+                <textarea
+                  name="short_description"
+                  id="short_description"
+                  rows="2"
+                  class="fieldItem-textarea"
+                  maxlength="160"
+                  placeholder="<%= polyglot.t('onboarding.ShortDescriptionPlaceholder') %>"><%= ob.page.profile.short_description %></textarea>
               </div>
             </div>
 

--- a/js/utils/saveToAPI.js
+++ b/js/utils/saveToAPI.js
@@ -9,8 +9,9 @@ module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData,
   var self = this,
       formData = new FormData(form[0] || ""),
       formKeys = [],
-      tempDisabledFields = [],
-      skipKeys = skipKeys || [];
+      tempDisabledFields = [];
+
+  skipKeys = skipKeys || [];
 
   if(form){
     form.addClass('formChecked');
@@ -34,24 +35,18 @@ module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData,
 
   //add manual data not in the form
   __.each(addData, function(value, key){
-    console.log(key);
     formKeys.push(key);
     if(value.constructor === Array){
       __.each(value, function(val){
-        console.log(val);
-        console.log(typeof val);
         formData.append(key, val);
       });
+      if(value.length == 0){
+        formData.append(key, "");
+      }
     }else{
       formData.append(key, value);
     }
   });
-
-  //add addresses in correct format or they will be destroyed by the server
-  if(endPoint == "settings" && modelJSON){
-    formKeys.push("shipping_addresses");
-    formData.append("shipping_addresses", JSON.stringify(modelJSON.shipping_addresses));
-  }
 
   //if key is not in formKeys, get value from the model
   if(modelJSON){
@@ -61,6 +56,9 @@ module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData,
           __.each(value, function(val){
             formData.append(key, val);
           });
+          if(value.length == 0){
+            formData.append(key, "");
+          }
         }else{
           formData.append(key, value);
         }

--- a/js/utils/saveToAPI.js
+++ b/js/utils/saveToAPI.js
@@ -4,12 +4,13 @@ var __ = require('underscore'),
     showErrorModal = require('../utils/showErrorModal.js');
 
 
-module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData) {
+module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData, skipKeys) {
   "use strict";
   var self = this,
       formData = new FormData(form[0] || ""),
       formKeys = [],
-      tempDisabledFields = [];
+      tempDisabledFields = [],
+      skipKeys = skipKeys || [];
 
   if(form){
     form.addClass('formChecked');
@@ -33,9 +34,12 @@ module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData)
 
   //add manual data not in the form
   __.each(addData, function(value, key){
+    console.log(key);
     formKeys.push(key);
     if(value.constructor === Array){
       __.each(value, function(val){
+        console.log(val);
+        console.log(typeof val);
         formData.append(key, val);
       });
     }else{
@@ -52,8 +56,14 @@ module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData)
   //if key is not in formKeys, get value from the model
   if(modelJSON){
     __.each(modelJSON, function (value, key) {
-      if (formKeys.indexOf(key) == -1){
-        formData.append(key, value);
+      if (formKeys.indexOf(key) == -1 && skipKeys.indexOf(key) == -1){
+        if(value.constructor === Array){
+          __.each(value, function(val){
+            formData.append(key, val);
+          });
+        }else{
+          formData.append(key, value);
+        }
       }
     });
   }

--- a/js/views/chatAppVw.js
+++ b/js/views/chatAppVw.js
@@ -186,7 +186,6 @@ module.exports = Backbone.View.extend({
     this.chatMessages.fetch({
       success: function(chatMessages, response) {
         if(chatMessages.models.length < 1) {
-          console.log('none found');
           $('#chatConversation .chatConversationContent').html(self.listWrapperChat);
         } else {
           __.each(chatMessages.models, function (chatMessage) {
@@ -199,8 +198,10 @@ module.exports = Backbone.View.extend({
             }
             if(chatMessage.get('outgoing')) {
               chatMessage.set('avatarURL', self.serverUrl + "get_image?hash=" + model.get('avatar_hash'));
-            } else {
+            } else if(chatMessage.get('image_hash')) {
               chatMessage.set('avatarURL', self.serverUrl  + "get_image?hash=" + chatMessage.get('image_hash') + "&guid=" + chatMessage.get('guid'));
+            } else {
+              chatMessage.set('avatarURL', "imgs/defaultItem.png");
             }
             self.renderChatMessage(chatMessage);
           });

--- a/js/views/homeVw.js
+++ b/js/views/homeVw.js
@@ -143,7 +143,6 @@ module.exports = Backbone.View.extend({
 
   setState: function(state){
     "use strict";
-    console.log("state: " + state);
     if(!state){
       state = "products";
     }
@@ -166,7 +165,6 @@ module.exports = Backbone.View.extend({
   scrollHandler: function(){
     "use strict";
     if(this.obContainer[0].scrollTop + this.obContainer[0].clientHeight + 200 > this.obContainer[0].scrollHeight){
-      console.log(this.loadingProducts);
       if(this.state == "products" && !this.loadingProducts){
         this.setSocketTimeout();
         this.loadingProducts = true;

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -192,8 +192,6 @@ module.exports = Backbone.View.extend({
         imageList = [],
         imageCount = imageFiles.length;
 
-    this.$el.find('.js-itemEditImageLoading').removeClass("fadeOut");
-
     __.each(imageFiles, function(imageFile, i){
       var newImage = document.createElement("img"),
           ctx;
@@ -204,6 +202,8 @@ module.exports = Backbone.View.extend({
             imgW = newImage.width,
             dataURI,
             canvas = document.createElement("canvas");
+
+        self.$el.find('.js-itemEditImageLoading').removeClass("fadeOut");
 
         if (imgW < imgH){
           //if image width is smaller than height, set width to max

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -539,6 +539,14 @@ module.exports = Backbone.View.extend({
     newAddress.country = this.$el.find('#settingsShipToCountry').val();
     newAddress.displayCountry = this.$el.find('#settingsShipToCountry option:selected').data('name');
 
+    //if form is partially filled out throw error
+    if(newAddress.name || newAddress.street || newAddress.city || newAddress.state || newAddress.postal_code) {
+      if(!newAddress.name || !newAddress.street || !newAddress.city || !newAddress.state || !newAddress.postal_code){
+        showErrorModal(window.polyglot.t('errorMessages.saveError'), window.polyglot.t('errorMessages.missingError'));
+        return
+      }
+    }
+
     if(newAddress.name && newAddress.street && newAddress.city && newAddress.state && newAddress.postal_code && newAddress.country) {
       newAddresses.push(JSON.stringify(newAddress));
     }
@@ -547,11 +555,7 @@ module.exports = Backbone.View.extend({
       newAddresses.push(JSON.stringify(self.model.get('user').shipping_addresses[$(this).val()]));
     });
 
-    if(newAddresses){
-      addressData.shipping_addresses = newAddresses;
-    }
-
-    console.log(newAddresses);
+    addressData.shipping_addresses = newAddresses;
 
     saveToAPI(form, this.model.get('user'), self.serverUrl + "settings", function(){
       "use strict";

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -119,7 +119,7 @@ module.exports = Backbone.View.extend({
         smallImage: "stretch",
         maxZoom: 2,
         onFileReaderError: function(data){console.log(data);},
-        onFileChange: function(){
+        onImageLoading: function(){
           self.$el.find('.js-avatarLoading').removeClass('fadeOut');
           self.newAvatar = true;
         },
@@ -141,7 +141,7 @@ module.exports = Backbone.View.extend({
         exportZoom: 1.33,
         maxZoom: 5,
         onFileReaderError: function(data){console.log(data);},
-        onFileChange: function(){
+        onImageLoading: function(){
           self.$el.find('.js-bannerLoading').removeClass('fadeOut');
           self.newBanner = true;
         },


### PR DESCRIPTION
- when app is closed state is saved and restored when app is opened again
- not hex number bug on Settings is fixed
- parsing and saving of shipping_addresses rewritten to eliminate parsing bug
- settings addresses page shows error if address is only partially filled out
- on first load, missing trigger to go to profile if user is new restored
- fixes issue with chat loading blank avatar hash values
- fixes issue with buying wizard trying to load missing avatars for offline moderators
- adds max length of 160 to the short description field in the settings view
- fixes onboarding avatar cropit element having duplicate ID with settings cropit element
- avatar and header images only loaded into cropit in settings view if they have hash values
