### PR TITLE
Preserving line breaks in listing descriptions

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -501,6 +501,7 @@ form {
 .rowItem {
   flex-grow: 1;
   padding: 25px 15px;
+  white-space: pre-line;
 }
 
 .rowItem input[type=radio] {

--- a/css/obBase.css
+++ b/css/obBase.css
@@ -501,7 +501,10 @@ form {
 .rowItem {
   flex-grow: 1;
   padding: 25px 15px;
-  white-space: pre-line;
+}
+
+.listing {
+  white-space: pre-line; 
 }
 
 .rowItem input[type=radio] {

--- a/css/obBase.css
+++ b/css/obBase.css
@@ -73,6 +73,10 @@ p a {
   text-decoration: underline;
 }
 
+p { 
+  white-space: pre-line;  
+}
+
 hr {
   border: solid 1px rgba(255,255,255,0.08);
   width: 100%;
@@ -501,10 +505,6 @@ form {
 .rowItem {
   flex-grow: 1;
   padding: 25px 15px;
-}
-
-.listing {
-  white-space: pre-line; 
 }
 
 .rowItem input[type=radio] {

--- a/js/templates/item.html
+++ b/js/templates/item.html
@@ -101,7 +101,7 @@
       <div class="flexContainer flex-border custCol-primary js-description js-tabTarg textOpacity75 minHeight300">
         <div class="flexRow">
           <div class="rowItem fontSize16 padding30 lineHeight24">
-            <p><%- ob.vendor_offer.listing.item.description %><p>
+            <p><%- ob.vendor_offer.listing.item.description %></p>
           </div>
         </div>
       </div>

--- a/js/templates/item.html
+++ b/js/templates/item.html
@@ -101,14 +101,14 @@
       <div class="flexContainer flex-border custCol-primary js-description js-tabTarg textOpacity75 minHeight300">
         <div class="flexRow">
           <div class="rowItem fontSize16 padding30 lineHeight24">
-            <%- ob.vendor_offer.listing.item.description %>
+            <p><%- ob.vendor_offer.listing.item.description %><p>
           </div>
         </div>
       </div>
       <div class="flexContainer flex-border custCol-primary minHeight300 textOpacity75 js-reviews js-tabTarg hide">
         <div class="flexRow">
           <div class="rowItem fontSize16 padding30 lineHeight24">
-            Placeholder for reviews
+            <p>Placeholder for reviews</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
My first pull request (hope I'm doing it right).

This change preserves line breaks for a listing description, reviews and shipping/returns.
