### PR TITLE
Set chatConversationContent width to 100%

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -1661,6 +1661,7 @@ div.chatSearchOut .chatSearchIcon {
   overflow: auto;
   padding: 6px 2px;
   margin-left: 2px;
+  width: 100%;
 }
 
 .chatConversationTo {


### PR DESCRIPTION
If you change the zoomFactor on the app, the css on the chat conversation doesn't adjust with it. 
