### PR TITLE
Fix to issue 433: everything too big in Hi DPI Linux

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -63,6 +63,17 @@ window.polyglot.extend(__.where(languages.get('languages'), {langCode: window.la
 //put the event bus into the window so it's available everywhere
 window.obEventBus =  __.extend({}, Backbone.Events);
 
+// fix zoom issue on Linux hiDPI
+var platform = process.platform;
+
+if(platform === "linux") {
+  var scaleFactor = require('screen').getPrimaryDisplay().scaleFactor;
+  if (scaleFactor === 0) {
+      scaleFactor = 1;
+  }
+  $("body").css("zoom", 1 / scaleFactor);
+}
+
 //record changes to the app state
 $(window).bind('hashchange', function(){
   "use strict";

--- a/valiquire-redirect.js
+++ b/valiquire-redirect.js
@@ -1,5 +1,5 @@
 'use strict';
-var electronModules = ['app', 'browser-window', 'crash-reporter', 'remote', 'shell', 'clipboard'];
+var electronModules = ['app', 'browser-window', 'crash-reporter', 'remote', 'shell', 'clipboard', 'screen'];
 
 module.exports = function redirect(request) {
   // Tell valiquire to ignore these modules


### PR DESCRIPTION
Fixes #433

This queries the electron screen api to get the scale factor of the
screen.  Then it uses 1 / scaleFactor as the zoom parameter for the
body tag css styles.  This is only done under Linux platform.

Also added screen to electron-modules so valiquire would work.
