### PR TITLE
Admin panel close btn fixed position

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -628,6 +628,12 @@ label.fieldItem {
   right: -30px;
 }
 
+.modal > .btn-corner.btn-cornerTRFixedOut {
+  /* button must be direct child of modal. The left value is based on the width of the modal. */
+  left: 896px;
+  top: 23px;
+}
+
 .thumbnail-small {
   height: 30px;
   width: 30px;

--- a/js/templates/adminPanel.html
+++ b/js/templates/adminPanel.html
@@ -1,8 +1,8 @@
 <div class="modal modal-opaque js-adminModal hide">
+  <div class="btn-corner btn-cornerTR btn-cornerTRFixedOut js-closeModal">
+    <h3 class="ion-close-circled icon-large"></h3>
+  </div>
   <div class="modal-child modal-childMain pad20 scrollOverflowY">
-    <div class="btn-corner btn-cornerTR js-closeModal">
-      <h3 class="ion-close-circled"></h3>
-    </div>
     <div class="row20 rowTop20">
       <h1 class="txt-center">Admin Panel</h1>
     </div>


### PR DESCRIPTION
When you scroll the admin panel, the close button remains visible, to the right of the modal.It's also bigger.
