### PR TITLE
Refresh PageNav only on Avatar Change

### DIFF
--- a/js/models/userProfileMd.js
+++ b/js/models/userProfileMd.js
@@ -99,6 +99,11 @@ module.exports = Backbone.Model.extend({
         response.profile.location = "UNITED_STATES";
       }
 
+      //put a copy of the avatar outside of the profile object, so change events can be triggered for it
+      if(response.profile.avatar_hash){
+        response.avatar_hash = response.profile.avatar_hash;
+      }
+
       //add randome number because change event is not triggered by changes inside profile
       response.fetched = Math.random();
     }

--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -210,7 +210,7 @@ module.exports = Backbone.View.extend({
         self.closeStatusBar();
       });
 
-      self.listenTo(self.userProfile, 'change', function(){
+      self.listenTo(self.userProfile, 'change:avatar_hash', function(){
         self.model.set('vendor', self.userProfile.get('profile').vendor);
         self.render();
       });


### PR DESCRIPTION
- previous fix for refreshing the avatar fired on any change to the userProfile model, due to the data being nested. This makes a copy of avatar_hash outside of the profile object, so change events can be listened to on it.
