### PR TITLE
Preserve formatting in user's about section

### DIFF
--- a/js/templates/userPage.html
+++ b/js/templates/userPage.html
@@ -167,7 +167,7 @@
         <div class="flexCol-8 custCol-border borderBottom0">
           <div class="rowItem">
             <% if(ob.page.profile.about) { %>
-              <%- ob.page.profile.about %>
+             <p><%- ob.page.profile.about %></p>
             <%}else{%>
               <span class="textOpacity75"><%= polyglot.t('AboutEmpty') %></span>
             <%}%>


### PR DESCRIPTION
This fixes the user portion of #260. The item description bug mentioned in that issue was fixed by 1230544.
