### PR TITLE
Fix languages and new item editing

### DIFF
--- a/js/models/languagesMd.js
+++ b/js/models/languagesMd.js
@@ -189,18 +189,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "Save Avatar",
         NewAvatar: "Select New Avatar",
         NewCoverImage: "Select New Cover Image",
-        Reset: "Reset",
         Loading: "Loading...", // not translated
         Purchases: "Purchases",
         Sales: "Sales",
         Cases: "Cases",
         Discover: "Discover",
-        Blocked: "Blocked",
-        Advanced: "Advanced",
-        General: "General",
-        Page: "Page",
         AllItems: "All Items",
-        Listing: "Listing",
         DomesticShippingPrice: "Domestic Shipping Price",
         InternationalShippingPrice: "International Shipping Price",
         MinimumIs: "Minimum is",
@@ -211,7 +205,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time",
         InternationalShippingTime: "International Shipping Time",
         DisplayNSFWcontent: "Display NSFW content?",
-        Basic: "Basic",
         Content: "Content",
         StandardThemes: "Standard themes",
         NoPhotosAdded: "No Photos Added",
@@ -498,18 +491,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "Guardar Avatar ",
         NewAvatar: "Seleccione Nuevo Avatar",
         NewCoverImage: "Seleccione Nueva Imagen de la Cubierta",
-        Reset: "Reset", // not translated
         Loading: "Loading...", // not translated
         Purchases:"Compras",
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         FreeShipping: "Free Shipping", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
@@ -521,7 +508,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated
@@ -815,18 +801,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "Avatar speichern",
         NewAvatar: "W&auml;hlen Sie New Avatar",
         NewCoverImage: "W&auml;hlen Sie New Cover Image",
-        Reset: "Reset", // not translated
         Loading: "Loading...", // not translated
         Purchases:"Eink&auml;ufe",
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         FreeShipping: "Free Shipping", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
@@ -838,7 +818,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated
@@ -1134,18 +1113,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "Salva Avatar",
         NewAvatar: "Selezionare Nuovo Avatar",
         NewCoverImage: "Selezionare Nuovo Copertina",
-        Reset: "Reset", // not translated
         Loading: "Loading...", // not translated
         Purchases:"Acquisti",
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
         MinimumIs: "Minimum is", // not translated
@@ -1156,7 +1129,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated
@@ -1452,18 +1424,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "Enregistrer un Avatar",
         NewAvatar: "Sélectionner un nouvel avatar",
         NewCoverImage: "Sélectionner une nouvelle image de couverture",
-        Reset: "Réinitialiser",
         Loading: "Chargement...",
         Purchases:"Achats",
         Sales: "Ventes",
         Cases: "Cas",
         Discover: "Découvrir",
-        Blocked: "Bloqué",
-        Advanced: "Avancé",
-        General: "Général",
-        Page: "Page",
         AllItems: "Tous les articles",
-        Listing: "Annonce",
         DomesticShippingPrice: "Prix d'expédition nationale",
         InternationalShippingPrice: "Prix d'expédition internationale",
         MinimumIs: "Le minimum est",
@@ -1474,7 +1440,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Délai d'expédition nationale",
         InternationalShippingTime: "Délai d'expédition internationale",
         DisplayNSFWcontent: "Afficher le contenu NSFW ?",
-        Basic: "Basic",
         Content: "Contenu",
         StandardThemes: "Thèmes standards",
         NoPhotosAdded: "Aucune photo ajoutée",
@@ -1768,18 +1733,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "Salvare Avatar",
         NewAvatar: "Selectare Avatar Nou",
         NewCoverImage: "Selectare Imagine Copertă Nouă",
-        Reset: "Reset", // not translated
         Loading: "Loading...", // not translated
         Purchases:"Cumpărături",
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         FreeShipping: "Free Shipping", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
@@ -1791,7 +1750,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated
@@ -2085,18 +2043,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "Сохранить аватар",
         NewAvatar: "Выбрать аватар",
         NewCoverImage: "Выбрать обложку",
-        Reset: "Сброс",
         Loading: "Loading...", // not translated
         Purchases:"Покупки",
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         FreeShipping: "Free Shipping", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
@@ -2108,7 +2060,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated
@@ -2344,18 +2295,11 @@ module.exports = Backbone.Model.extend({
         Condition: "Podmienka",
         NSFW: "18+ (obsah pre dospelých)",
         Select: "Select", //not translated
-        Basic: "Basic", //not translated
         Social: "Social", //not translated
         Theme: "Theme", //not translated
-        Listing: "Listing", //not translated
         Listings: "Listings", //not translated
         Pages: "Pages", //not translated
-        Page: "Page", //not translated
-        Blocked: "Blocked", //not translated
-        Advanced: "Advanced", //not translated
-        General: "General", //not translated
         Language: "Language", //not translated
-        Reset: "Reset", //not translated
         Local: "Lokálne",
         Domestic: "Vnútroštátne",
         Location: "Lokalita",
@@ -2720,18 +2664,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "Avatarı Kaydet",
         NewAvatar: "Yeni Avatar Seç",
         NewCoverImage: "Yeni Kapak Görseli Seç",
-        Reset: "Sıfırla",
         Loading: "Loading...", // not translated
         Purchases: "Purchases", //not translated
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
         MinimumIs: "Minimum is", // not translated
@@ -2742,7 +2680,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated
@@ -3037,18 +2974,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "QaD mIllogh nob",
         NewAvatar: "QaD mIllogh wIv",
         NewCoverImage: "Yuvtlhe' mIllogh wIv",
-        Reset: "Reset", // not translated
         Loading: "Loading...", // not translated
         Purchases:"Je'",
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
         MinimumIs: "Minimum is", // not translated
@@ -3059,7 +2990,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated
@@ -3353,18 +3283,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "保存 Avatar",
         NewAvatar: "选择新的 Avatar",
         NewCoverImage: "选择新的封面照片",
-        Reset: "重置",
         Loading: "Loading...", // not translated
         Purchases: "Purchases", // not translated
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
         MinimumIs: "Minimum is", // not translated
@@ -3375,7 +3299,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated
@@ -3671,18 +3594,12 @@ module.exports = Backbone.Model.extend({
         SaveAvatar: "정장 화신",
         NewAvatar: "새로운 화신 선택",
         NewCoverImage: "새로운 표지사진 선택",
-        Reset: "Reset", // not translated
         Loading: "Loading...", // not translated
         Purchases: "Purchases", // not translated
         Sales: "Sales", // not translated
         Cases: "Cases", // not translated
         Discover: "Discover", // not translated
-        Blocked: "Blocked", // not translated
-        Advanced: "Advanced", // not translated
-        General: "General", // not translated
-        Page: "Page", // not translated
         AllItems: "All Items", // not translated
-        Listing: "Listing", // not translated
         DomesticShippingPrice: "Domestic Shipping Price", // not translated
         InternationalShippingPrice: "International Shipping Price", // not translated
         MinimumIs: "Minimum is", // not translated
@@ -3693,7 +3610,6 @@ module.exports = Backbone.Model.extend({
         DomesticShippingTime: "Domestic Shipping Time", // not translated
         InternationalShippingTime: "International Shipping Time", // not translated
         DisplayNSFWcontent: "Display NSFW content?", // not translated
-        Basic: "Basic", // not translated
         Content: "Content", // not translated
         StandardThemes: "Standard themes", // not translated
         NoPhotosAdded: "No Photos Added", // not translated

--- a/js/router.js
+++ b/js/router.js
@@ -111,8 +111,10 @@ module.exports = Backbone.Router.extend({
     this.cleanup();
     this.newView(new userPageView({
       userModel: this.userModel,
+      userProfile: this.userProfile,
       state: 'itemNew',
-      socketView: this.socketView
+      socketView: this.socketView,
+      chatAppView: this.chatAppView
     }),"userPage");
   },
 

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -153,6 +153,7 @@ module.exports = Backbone.View.extend({
 
   initialize: function (options) {
     "use strict";
+    console.log("init");
     var self = this;
     this.options = options || {};
     /* expected options are:
@@ -188,6 +189,7 @@ module.exports = Backbone.View.extend({
     this.chatAppView = options.chatAppView;
     this.slimVisible = false;
     this.confirmDelete = false;
+    this.state = this.options.state;
     this.lastTab = "about"; //track the last tab clicked
     //flag to hold state when customizing
     this.customizing = false;
@@ -267,6 +269,7 @@ module.exports = Backbone.View.extend({
 
   render: function(){
     "use strict";
+    console.log("render");
     var self = this;
     //make sure container is cleared
     $('#content').html(this.$el);
@@ -280,7 +283,7 @@ module.exports = Backbone.View.extend({
       self.undoCustomAttributes.secondary_color = self.model.get('page').profile.secondary_color;
       self.undoCustomAttributes.text_color = self.model.get('page').profile.text_color;
       self.setCustomStyles();
-      self.setState(self.options.state, self.options.itemHash);
+      self.setState(self.state, self.options.itemHash);
       self.$el.find('.js-externalLink').on('click', function(e){
         e.preventDefault();
         var extUrl = $(this).attr('href');
@@ -348,6 +351,7 @@ module.exports = Backbone.View.extend({
 
   setState: function(state, hash) {
     "use strict";
+    console.log("state " + state);
     var currentAddress,
         addressState,
         currentHandle = this.model.get('page').profile.handle;
@@ -363,6 +367,7 @@ module.exports = Backbone.View.extend({
     }else if(state === "itemNew"){
       this.tabClick(this.$el.find(".js-storeTab"), this.$el.find(".js-store"));
       $('#obContainer').scrollTop(352);
+      this.addTabToHistory('newItem');
       this.sellItem();
     } else if(state === "createStore"){
       this.tabClick(this.$el.find(".js-aboutTab"), this.$el.find(".js-about"));
@@ -380,8 +385,12 @@ module.exports = Backbone.View.extend({
       this.tabClick(this.$el.find(".js-storeTab"), this.$el.find(".js-store"));
     }
     this.setControls(state);
-    if(state !== "customize"){
-      this.lastTab = state;
+    console.log(state != "itemNew");
+    if(state != "customize" && state != this.state && state != "itemNew" && this.state != "itemNew"){
+      this.lastTab = this.state;
+      this.state = state;
+      console.log("this.state " + this.state);
+      console.log("this.lastTab " + this.lastTab);
     }
 
     //set address bar
@@ -399,7 +408,7 @@ module.exports = Backbone.View.extend({
       addressState = state;
     }
     currentAddress = this.model.get('page').profile.guid + "/" + addressState;
-    if(addressState === "item") {
+    if(addressState === "item" && hash) {
       currentAddress += "/"+ hash;
     } else if(addressState === "createStore"){
       currentAddress = this.model.get('page').profile.guid;
@@ -417,10 +426,11 @@ module.exports = Backbone.View.extend({
     document.getElementById('obContainer').classList.remove("noScrollBar");
     document.getElementById('obContainer').classList.remove("overflowHidden");
     //unhide the ones that are needed
+    console.log(state);
     if(this.options.ownPage === true) {
       if(state === "item" || state === "itemOld") {
         this.$el.find('.js-itemButtons').removeClass('hide');
-      } else if(state === "itemEdit") {
+      } else if(state === "itemEdit" || state === "itemNew") {
         this.$el.find('.js-itemEditButtons').removeClass('hide');
       } else if(state === "customize") {
         this.$el.find('.js-pageCustomizationButtons').removeClass('hide');
@@ -429,7 +439,6 @@ module.exports = Backbone.View.extend({
         document.getElementById('obContainer').classList.add("box-borderDashed");
         document.getElementById('obContainer').classList.add("noScrollBar");
         document.getElementById('obContainer').classList.add("overflowHidden");
-
       } else {
         this.$el.find('.js-pageButtons').removeClass('hide');
       }
@@ -1112,7 +1121,7 @@ module.exports = Backbone.View.extend({
   storeCreated: function() {
     "use strict";
     //this.storeWizardView.closeWizard();
-    var currentState = this.lastTab || "about";
+    //var currentState = this.lastTab || "about";
     //recreate the entire page with the new data
     Backbone.history.loadUrl();
   },


### PR DESCRIPTION
- duplicate language keys were introduced in a merge, which causes an es-lint error, they are removed
- the new link in the menu caused various problem with the page state, this is fixed
- when going directly to the "newItem" state, "lastTab" was set to "newItem", creating a loop when the cancel button was pressed (it would try to go back to the new item state). This is fixed.
- the save and cancel buttons now display correctly at the top of the page
- the "newItem" state wasn't added to history, this caused the page hash to remain at #sellItem when the New link in the menu was clicked and an item was saved, which prevented the New link from being usable a second time (since the router thought the user was trying to navigate to the state they were already in). This is fixed.

closes #478 
closes #479
