### PR TITLE
Changes to make tabbing work in onboarding

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -843,6 +843,14 @@ table, td {
   float: left;
 }
 
+.accordion-active input, .accordion-active textarea, .accordion-active a {
+  visibility: visible;
+}
+
+.accordion-inactive input, .accordion-inactive textarea, .accordion-inactive a {
+  visibility: hidden;
+}
+
 .positionWrapper {
   /* use when you need a generic element around one or more elements where one is absolutely positioned */
   position: relative;

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -116,7 +116,7 @@
       </div>
       <div class="homeModal-accordion accordion js-profileAccordion">
         <div class="accordion-window">
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-active custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.chooseLanguage') %>
               <span class="textOpacity75 fontSize14 floatRight">1 <%= polyglot.t('of') %> 10</span>
@@ -130,14 +130,14 @@
               <div class="js-homeModal-languageList flex-border"></div>
             </div>
             <div class="bar barFlush">
-              <a class="btn btn-bar btn-wide js-accordionNext custCol-secondary borderBottomLeftRaidus3 borderBottomRightRaidus3 custCol-text">
+              <a class="btn btn-bar btn-wide js-accordionNext custCol-secondary borderBottomLeftRaidus3 borderBottomRightRaidus3 custCol-text" tabIndex="0">
                 <%= polyglot.t('Next') %>
                 <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
               </a>
             </div>
           </div>
 
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('Introduction') %>
               <span class="textOpacity75 fontSize14 floatRight">2 <%= polyglot.t('of') %> 10</span>
@@ -150,18 +150,18 @@
               </div>
             </div>
             <div class="bar barFlush borderBottomLeftRaidus3 borderBottomRightRaidus3">
-              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                 <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                 <%= polyglot.t('Back') %>
               </a>
-              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                 <%= polyglot.t('Next') %>
                 <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
               </a>
             </div>
           </div>
 
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.yourCountry') %>
               <span class="textOpacity75 fontSize14 floatRight">3 <%= polyglot.t('of') %> 10</span>
@@ -174,18 +174,18 @@
               </div>
               <div class="js-homeModal-countryList flex-border"></div>
               <div class="bar barFlush borderBottomLeftRaidus3 borderBottomRightRaidus3">
-                <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+                <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                   <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                   <%= polyglot.t('Back') %>
                 </a>
-                <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+                <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                   <%= polyglot.t('Next') %>
                   <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
                 </a>
               </div>
             </div>
           </div>
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.localCurrency') %>
               <span class="textOpacity75 fontSize14 floatRight">4 <%= polyglot.t('of') %> 10</span>
@@ -198,18 +198,18 @@
               </div>
               <div class="js-homeModal-currencyList flex-border"></div>
               <div class="bar barFlush borderBottomLeftRaidus3 borderBottomRightRaidus3">
-                <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+                <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                   <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                   <%= polyglot.t('Back') %>
                 </a>
-                <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+                <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                   <%= polyglot.t('Next') %>
                   <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
                 </a>
               </div>
             </div>
           </div>
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.timeZone') %>
               <span class="textOpacity75 fontSize14 floatRight">5 <%= polyglot.t('of') %> 10</span>
@@ -410,17 +410,17 @@
               </ul>
             </div>
             <div class="bar barFlush borderBottomLeftRaidus3 borderBottomRightRaidus3">
-              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                 <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                 <%= polyglot.t('Back') %>
               </a>
-              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                 <%= polyglot.t('Next') %>
                 <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
               </a>
             </div>
           </div>
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.yourDetails') %> (<%= polyglot.t('Optional') %>)
               <span class="textOpacity75 fontSize14 floatRight">6 <%= polyglot.t('of') %> 10</span>
@@ -478,17 +478,17 @@
               </div>
             </div>
             <div class="bar barFlush borderBottomLeftRaidus3 borderBottomRightRaidus3">
-              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                 <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                 <%= polyglot.t('Back') %>
               </a>
-              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                 <%= polyglot.t('Next') %>
                 <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
               </a>
             </div>
           </div>
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.theme') %>
               <span class="textOpacity75 fontSize14 floatRight">7 <%= polyglot.t('of') %> 10</span>
@@ -611,18 +611,18 @@
               </div>
             </div>
             <div class="bar barFlush borderBottomLeftRaidus3 borderBottomRightRaidus3">
-              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                 <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                 <%= polyglot.t('Back') %>
               </a>
-              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                 <%= polyglot.t('Next') %>
                 <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
               </a>
             </div>
           </div>
 
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.avatar') %> (<%= polyglot.t('Optional') %>)
               <span class="textOpacity75 fontSize14 floatRight">8 <%= polyglot.t('of') %> 10</span>
@@ -643,18 +643,18 @@
               </div>
             </div>
             <div class="bar barFlush borderBottomLeftRaidus3 borderBottomRightRaidus3">
-              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                 <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                 <%= polyglot.t('Back') %>
               </a>
-              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                 <%= polyglot.t('Next') %>
                 <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
               </a>
             </div>
           </div>
 
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.recommended') %> (<%= polyglot.t('Optional') %>)
               <span class="textOpacity75 fontSize14 floatRight">9 <%= polyglot.t('of') %> 10</span>
@@ -715,18 +715,18 @@
               </div>
             </div>
             <div class="bar barFlush custCol-secondary borderBottomLeftRaidus3 borderBottomRightRaidus3">
-              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                 <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                 <%= polyglot.t('Back') %>
               </a>
-              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+              <a class="btn btn-bar btn-half js-accordionNext custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                 <%= polyglot.t('Next') %>
                 <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
               </a>
             </div>
           </div>
 
-          <div class="accordion-child custCol-primary">
+          <div class="accordion-child accordion-inactive custCol-primary">
             <div class="bar barTxt h6 custCol-secondary custCol-text">
               <%= polyglot.t('onboarding.disclaimer_title') %>
               <span class="textOpacity75 fontSize14 floatRight">10 <%= polyglot.t('of') %> 10</span>
@@ -739,11 +739,11 @@
               </div>
             </div>
             <div class="bar barFlush custCol-secondary borderBottomLeftRaidus3 borderBottomRightRaidus3">
-              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight">
+              <a class="btn btn-bar btn-half js-accordionPrev custCol-secondary custCol-border-primary borderBottomLeftRaidus3 custCol-text borderRight" tabIndex="0">
                 <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
                 <%= polyglot.t('Back') %>
               </a>
-              <a class="btn btn-bar btn-half js-homeModalDone custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text">
+              <a class="btn btn-bar btn-half js-homeModalDone custCol-secondary custCol-border-primary borderBottomRightRaidus3 custCol-text" tabIndex="0">
                 <span class="ion-checkmark fontSize10 marginRight2 textOpacity75"></span>
                 <%= polyglot.t('IAgree') %>
               </a>

--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -43,7 +43,10 @@ module.exports = Backbone.View.extend({
     'click .js-homeModal-cancelHandle': 'cancelHandle',
     'click .js-accordionNext': 'accNext',
     'click .js-accordionPrev': 'accPrev',
+    'keypress .js-accordionNext': 'accNextKeypress',
+    'keypress .js-accordionPrev': 'accPrevKeypress',
     'click .js-homeModalDone': 'settingsDone',
+    'keypress .js-homeModalDone': 'settingsDoneKeypress',
     'keyup .js-navAddressBar': 'addressBarKeyup',
     'click .js-closeStatus': 'closeStatusBar',
     'click .js-homeModal-themeSelected': 'setSelectedTheme',
@@ -152,8 +155,13 @@ module.exports = Backbone.View.extend({
       this.accWin.css('left', function(){
         return oldPos - moveBy;
       });
+      // switch active tab
+      var curActive = $(this.$el).find('.accordion-active');
+      curActive.addClass('accordion-inactive').removeClass('accordion-active');
+      var newActive = curActive.next('.accordion-child');
+      newActive.addClass('accordion-active').removeClass('accordion-inactive');
       // focus search input
-      $(this).closest('.accordion-child').next('.accordion-child').find('.search').focus();
+      newActive.find('.search').focus();
     }
   },
 
@@ -167,9 +175,36 @@ module.exports = Backbone.View.extend({
       this.accWin.css('left', function(){
         return oldPos + moveBy;
       });
+      // switch active tab
+      var curActive = $(this.$el).find('.accordion-active');
+      curActive.addClass('accordion-inactive').removeClass('accordion-active');
+      var newActive = curActive.prev('.accordion-child');
+      newActive.addClass('accordion-active').removeClass('accordion-inactive');
       // focus search input
-      $(this).closest('.accordion-child').prev('.accordion-child').find('.search').focus();
+      newActive.find('.search').focus();
     }
+  },
+
+  triggerOnEnterSpace: function(e, cb) {
+    "use strict";
+    switch (e.which) {
+      case 32: // space
+      case 13: // return
+        event.stopPropagation;
+        return cb(e);
+    }
+    return true;
+ 
+  },
+
+  accNextKeypress: function(e) {
+    "use strict";
+    this.triggerOnEnterSpace(e, this.accNext.bind(this));
+  },
+
+  accPrevKeypress: function(e) {
+    "use strict";
+    this.triggerOnEnterSpace(e, this.accPrev.bind(this));
   },
 
   closeNav: function(){
@@ -193,8 +228,17 @@ module.exports = Backbone.View.extend({
     loadTemplate('./js/templates/pageNav.html', function(loadedTemplate) {
       self.$el.html(loadedTemplate(self.model.toJSON()));
       if(localStorage.getItem("onboardingComplete") != "true") {
-        self.$el.find('.js-homeModal').removeClass("hide");
+        var modal = self.$el.find('.js-homeModal');
+        modal.removeClass("hide");
         $('#obContainer').addClass("blur");
+        modal.attr("tabIndex", "0");
+        document.addEventListener('focus', function( ev ) {
+          if ( !modal.hasClass("hide") && !$.contains( modal[0], ev.target ) ) {
+            ev.stopPropagation();
+            modal.focus();
+          }
+        }, true);
+
         self.countryList = new countryListView({el: '.js-homeModal-countryList', selected: self.model.get('country')});
         self.currencyList = new currencyListView({el: '.js-homeModal-currencyList', selected: self.model.get('currency_code')});
         self.languageList = new languageListView({el: '.js-homeModal-languageList', selected: self.model.get('language')});
@@ -673,6 +717,11 @@ module.exports = Backbone.View.extend({
 
   },
 
+  settingsDoneKeypress: function(e) {
+    "use strict";
+    this.triggerOnEnterSpace(e, this.settingsDone.bind(this));
+  },
+    
   navAdminPanel: function(){
     "use strict";
     this.$el.find('.js-adminModal').removeClass('hide');


### PR DESCRIPTION
Fixes #334 partially.  Similar technique needed in other modals / accordions.
When modal is open, focus will not go to background elements
Added tabindex 0 to the anchor buttons so they can get focus
Added keypress event handler so you can click the buttons with enter or
space
Added accordion-active and accordion-inactive classes so elements on
inactive pages will be hidden and won't get focus.
