### PR TITLE
Patch taggle

### DIFF
--- a/js/utils/loadTemplate.js
+++ b/js/utils/loadTemplate.js
@@ -5,13 +5,7 @@ var path = require('path');
 module.exports = function(templateFile, callback){
 
   var cur_dir = path.dirname(require.main.filename);
-  fs.readFile(cur_dir + path.sep + templateFile, "utf8", function(err, ob){
-
-    if (err) {
-      throw err;
-    }
-    __.templateSettings.variable = "ob";
-    var tmpl = __.template(ob);
-    callback(tmpl);
-  });
+  var file = fs.readFileSync(cur_dir + path.sep + templateFile, "utf8");
+  __.templateSettings.variable = "ob";
+  callback(__.template(file));
 };

--- a/js/utils/loadTemplate.js
+++ b/js/utils/loadTemplate.js
@@ -5,7 +5,13 @@ var path = require('path');
 module.exports = function(templateFile, callback){
 
   var cur_dir = path.dirname(require.main.filename);
-  var file = fs.readFileSync(cur_dir + path.sep + templateFile, "utf8");
-  __.templateSettings.variable = "ob";
-  callback(__.template(file));
+  fs.readFile(cur_dir + path.sep + templateFile, "utf8", function(err, ob){
+
+    if (err) {
+      throw err;
+    }
+    __.templateSettings.variable = "ob";
+    var tmpl = __.template(ob);
+    callback(tmpl);
+  });
 };

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -113,10 +113,15 @@ module.exports = Backbone.View.extend({
     var keywordTags = this.model.get('vendor_offer').listing.item.keywords;
     keywordTags = keywordTags ? keywordTags.filter(Boolean) : [];
     //activate tags plugin
-    this.inputKeyword = new Taggle('inputKeyword', {
-      tags: keywordTags,
-      saveOnBlur: true
-    });
+    //hacky fix for now, because DOM is not complete when taggle is called, resulting in a container size of zero
+    //TODO: find a fix for this, so taggle is initialized after reflow is complete
+    window.setTimeout(function(){
+      this.inputKeyword = new Taggle('inputKeyword', {
+        tags: keywordTags,
+        saveOnBlur: true
+      });
+    },1);
+
 
     //set chosen inputs
     $('.chosen').chosen({width: '100%'});


### PR DESCRIPTION
This adds a 1ms timeout to the initialization of taggle on the item edit view. The recent changes to loadTemplate appear to be causing taggle to try and read the size of it's container before it's added to the DOM, resulting in it thinking the size is zero. 

This should be a temporary fix until we figure out what's really going on.
