### PR TITLE
Stop drag and drop from working

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -80,6 +80,16 @@ $(window).bind('hashchange', function(){
   localStorage.setItem('route', Backbone.history.getFragment());
 });
 
+//prevent dragging a file to the window from loading that file
+window.addEventListener("dragover",function(e){
+  e = e || event;
+  e.preventDefault();
+},false);
+window.addEventListener("drop",function(e){
+  e = e || event;
+  e.preventDefault();
+},false);
+
 var setCurrentBitCoin = function(cCode, userModel, callback) {
   "use strict";
   getBTPrice(cCode, function (btAve, currencyList) {

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -60,19 +60,6 @@ module.exports = Backbone.View.extend({
     loadTemplate('./js/templates/itemEdit.html', function(loadedTemplate) {
       self.$el.html(loadedTemplate(self.model.toJSON()));
       self.setFormValues();
-
-      // prevent the body from picking up drag actions
-      //TODO: make these nice backbone events
-      $(document.body).bind("dragover", function(e) {
-        e.preventDefault();
-        return false;
-      });
-
-      $(document.body).bind("drop", function(e){
-        e.preventDefault();
-        return false;
-      });
-      
     });
     return this;
   },


### PR DESCRIPTION
Intercepts the drag action so users can't drag a file to the window and have it take over the window (which is default Chromium behavior)
