### PR TITLE
Don't select tabs in item view from user view

### DIFF
--- a/js/templates/userPage.html
+++ b/js/templates/userPage.html
@@ -175,7 +175,7 @@
     </div>
   </div>
 
-  <div class="bar navBar barFlush user-page-navigation custCol-secondary height55">
+  <div class="bar navBar barFlush user-page-navigation custCol-secondary height55 js-userPageTabs">
     <a class="btn btn-bar btn-tab custCol-secondary js-aboutTab js-tab">
       <span class="ion-ios-book fontSize11 marginRight2 textOpacity1"></span>
       <%= polyglot.t('About') %>
@@ -207,7 +207,7 @@
     </div>
     <% } %>
   </div>
-  <div class="userPage-subViews custCol-primary minHeight650">
+  <div class="userPage-subViews custCol-primary minHeight650 js-userPageSubViews">
     <div class="flexContainer flex-border custCol-primary hide js-about js-tabTarg minHeight650">
       <div class="flexRow minHeight650">
         <div class="flexCol-8 custCol-border borderBottom0">

--- a/js/views/itemVw.js
+++ b/js/views/itemVw.js
@@ -42,7 +42,7 @@ module.exports = Backbone.View.extend({
         allowedTags: [ 'h2','h3', 'h4', 'h5', 'h6', 'p', 'a','u','ul', 'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'hr', 'br', 'img', 'blockquote' ]
       });
 
-      $('.js-listingDescription').html(description);
+      self.$('.js-listingDescription').html(description);
     });
 
     return this;

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -840,9 +840,9 @@ module.exports = baseVw.extend({
 
   tabClick: function(activeTab, showContent){
     "use strict";
-    this.$el.find('.js-tab').removeClass('active');
+    this.$('.js-userPageTabs > .js-tab').removeClass('active');
     activeTab.addClass('active');
-    this.$el.find('.js-tabTarg').addClass('hide');
+    this.$('.js-userPageSubViews > .js-tabTarg').addClass('hide');
     showContent.removeClass('hide');
   },
 


### PR DESCRIPTION
- jQuery selector in parent view of item was selecting tabs in item view
- fixes tabs and tab targets all being set to inactive and hidden in item
