### PR TITLE
Fix clicking on icon in select box

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -3718,6 +3718,7 @@ input[type="checkbox"].fieldItem:checked + label .togLabelOff {
   opacity: .5;
   top: 0;
   right: 6px;
+  pointer-events: none;
 }
 
 .selectPill:hover {


### PR DESCRIPTION
- sets pointer-events: none on the icon, so it doesn't block the select box from opening.
