### PR TITLE
Don't pre-select language

### DIFF
--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -94,9 +94,9 @@ module.exports = Backbone.View.extend({
         break;
       }
     }
-    localLanguage = localLanguageFound ? localLanguage : "en-US";
-    this.model.set('language', localLanguage);
-    this.createTranslation(localLanguage);
+    //localLanguage = localLanguageFound ? localLanguage : "en-US";
+    //this.model.set('language', localLanguage);
+    //this.createTranslation(localLanguage);
 
     this.render();
   },


### PR DESCRIPTION
Commenting this out for now. The code to pre-select a language in
onboarding is overwriting the user's chosen language if they start the
app on the discover page.

This code will work differently when the new startup sequence is done, and onboarding is a separate view from pageNavVw.js. It will be more permanently fixed then.

Closes #654 
