### PR TITLE
Add Comments to Order Confirmation

### DIFF
--- a/js/models/languagesMd.js
+++ b/js/models/languagesMd.js
@@ -289,6 +289,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order",
           ReceivingAddress: "Receiving Address",
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at",
+          Comments: "Comments",
+          CommentsPlaceHolder: "Comments on the order, if any",
           Shipper: "Item Shipped By",
           ShipperPlaceholder: "Name of the company shipping the item",
           TrackingNumber: "Tracking Number",
@@ -733,6 +735,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -1174,6 +1178,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -1619,6 +1625,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -2064,6 +2072,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirmer cette commande",
           ReceivingAddress: "Adresse de réception",
           RecievingAddressPlaceholder: "L'adresse Bitcoin à laquelle vous recevrez le paiement",
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Article expédié par",
           ShipperPlaceholder: "Nom de l'entreprise expédiant l'article",
           TrackingNumber: "Numéro de suivi",
@@ -2506,6 +2516,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -2947,6 +2959,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -3388,6 +3402,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -3833,6 +3849,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -4277,6 +4295,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -4721,6 +4741,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -5166,6 +5188,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -5596,6 +5620,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Confirm Order", // not translated
           ReceivingAddress: "Receiving Address", // not translated
           RecievingAddressPlaceholder: "Bitcoin address you will receive payment at", // not translated
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Item Shipped By", // not translated
           ShipperPlaceholder: "Name of the company shipping the item", // not translated
           TrackingNumber: "Tracking Number", // not translated
@@ -6040,6 +6066,8 @@ module.exports = Backbone.Model.extend({
           ConfirmOrder: "Potwierdź to zamówienie",
           ReceivingAddress: "Adres odbiorczy",
           RecievingAddressPlaceholder: "Adres portfela, na którzy otrzymasz płatność",
+          Comments: "Comments", // not translated
+          CommentsPlaceHolder: "Comments on the order, if any", // not translated
           Shipper: "Wysłane przez",
           ShipperPlaceholder: "Firma przesyłkowa",
           TrackingNumber: "Numer śledzenia",

--- a/js/templates/transactionModal.html
+++ b/js/templates/transactionModal.html
@@ -285,12 +285,12 @@
     <div class="flexRow custCol-border borderBottom">
       <div class="flexRow rowItem padding2015">
         <div>
-          <% if( ob.vendor_order_confirmation.invoice.shipping) { %>
           <div class="pad10left txt-unleaded fontSize13 textOpacity1 marginTop12">
             <strong><%= polyglot.t('transactions.Comments') %>:</strong>
-            <%- ob.vendor_order_confirmation.invoice.shipping.comments
-            ? ob.vendor_order_confirmation.invoice.shipping.comments : polyglot.t('transactions.NoneSent') %>
+            <%- ob.vendor_order_confirmation.invoice.comments
+            ? ob.vendor_order_confirmation.invoice.comments : polyglot.t('transactions.NoneSent') %>
           </div>
+          <% if( ob.vendor_order_confirmation.invoice.shipping) { %>
           <div class="pad10left txt-unleaded fontSize13 textOpacity1 marginTop12">
             <strong><%= polyglot.t('transactions.EstimatedDelivery') %>:</strong>
             <%- ob.vendor_order_confirmation.invoice.shipping.est_delivery ?
@@ -544,13 +544,13 @@
         <div class="flexRow custCol-border borderTop">
           <div class="flexCol-4 borderRight custCol-border">
             <div class="fieldItem">
-              <label for="inputComments"><%= polyglot.t('transactions.Shipper') %></label>
+              <label for="inputComments"><%= polyglot.t('transactions.Comments') %></label>
               <div class="note"><%= polyglot.t('maxLength200') %></div>
             </div>
           </div>
           <div class="flexCol-8">
             <textarea name="comments"
-                      rows="2"
+                      rows="6"
                       maxlength="200"
                       class="fieldItem-textarea custCol-text"
                       id="inputComments"

--- a/js/templates/transactionModal.html
+++ b/js/templates/transactionModal.html
@@ -265,7 +265,6 @@
     </div>
   </div>
 
-  <% if(ob.buyer_order.order.shipping) { %>
   <div class="js-main js-shipping hide">
     <div class="flexRow custCol-border borderBottom">
       <div class="flexRow rowItem padding2015">
@@ -281,6 +280,7 @@
     </div>
 
     <!-- only display if vendor_order_confirmation exists -->
+    <%- ob.vendor_order_confirmation %>
     <% if( ob.vendor_order_confirmation) { %>
     <div class="flexRow custCol-border borderBottom">
       <div class="flexRow rowItem padding2015">
@@ -325,9 +325,7 @@
       </div>
     </div>
     <% } %>
-
   </div>
-  <% } %>
 
   <div class="js-main js-funds hide">
     <div class="flexRow scrollOverflowY" style="height: 319px;">

--- a/js/templates/transactionModal.html
+++ b/js/templates/transactionModal.html
@@ -287,6 +287,11 @@
         <div>
           <% if( ob.vendor_order_confirmation.invoice.shipping) { %>
           <div class="pad10left txt-unleaded fontSize13 textOpacity1 marginTop12">
+            <strong><%= polyglot.t('transactions.Comments') %>:</strong>
+            <%- ob.vendor_order_confirmation.invoice.shipping.comments
+            ? ob.vendor_order_confirmation.invoice.shipping.comments : polyglot.t('transactions.NoneSent') %>
+          </div>
+          <div class="pad10left txt-unleaded fontSize13 textOpacity1 marginTop12">
             <strong><%= polyglot.t('transactions.EstimatedDelivery') %>:</strong>
             <%- ob.vendor_order_confirmation.invoice.shipping.est_delivery ?
             ob.vendor_order_confirmation.invoice.shipping.est_delivery : polyglot.t('transactions.NoneSent') %>
@@ -534,6 +539,24 @@
                    placeholder="<%= polyglot.t('transactions.RecievingAddressPlaceholder') %>"
                    pattern="<%- ob.bitcoinValidationRegex %>"
             >
+          </div>
+        </div>
+        <div class="flexRow custCol-border borderTop">
+          <div class="flexCol-4 borderRight custCol-border">
+            <div class="fieldItem">
+              <label for="inputComments"><%= polyglot.t('transactions.Shipper') %></label>
+              <div class="note"><%= polyglot.t('maxLength200') %></div>
+            </div>
+          </div>
+          <div class="flexCol-8">
+            <textarea name="comments"
+                      rows="2"
+                      maxlength="200"
+                      class="fieldItem-textarea custCol-text"
+                      id="inputComments"
+                      placeholder="<%= polyglot.t('transactions.CommentsPlaceholder') %>"
+                      required>
+            </textarea>
           </div>
         </div>
         <% if(ob.vendor_offer.listing.metadata.category == "physical good") { %>

--- a/js/templates/transactionModal.html
+++ b/js/templates/transactionModal.html
@@ -65,7 +65,7 @@
       <span class="ion-android-list fontSize12 marginRight2 textOpacity1"></span>
       <%= polyglot.t('Summary') %>
     </a>
-    <% if(ob.buyer_order.order.shipping) { %>
+    <% if(ob.vendor_order_confirmation) { %>
     <a class="btn btn-bar btn-tab custCol-secondary js-tab js-shippingTab" data-tab="shipping">
       <span class="ion-cube fontSize11 marginRight2 textOpacity1"></span>
       <%= polyglot.t('Shipping') %>
@@ -265,7 +265,9 @@
     </div>
   </div>
 
+
   <div class="js-main js-shipping hide">
+    <% if(ob.buyer_order.order.shipping) { %>
     <div class="flexRow custCol-border borderBottom">
       <div class="flexRow rowItem padding2015">
         <div class="pad10left txt-unleaded">
@@ -278,9 +280,9 @@
         </div>
       </div>
     </div>
+    <% } %>
 
     <!-- only display if vendor_order_confirmation exists -->
-    <%- ob.vendor_order_confirmation %>
     <% if( ob.vendor_order_confirmation) { %>
     <div class="flexRow custCol-border borderBottom">
       <div class="flexRow rowItem padding2015">
@@ -325,7 +327,9 @@
       </div>
     </div>
     <% } %>
+
   </div>
+
 
   <div class="js-main js-funds hide">
     <div class="flexRow scrollOverflowY" style="height: 319px;">

--- a/js/utils/saveToAPI.js
+++ b/js/utils/saveToAPI.js
@@ -4,7 +4,7 @@ var __ = require('underscore'),
     messageModal = require('../utils/messageModal.js');
 
 
-module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData, skipKeys) {
+module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData, skipKeys, onInvalid) {
   "use strict";
   /* form[optional]: the form to pull data from, as a jQuery object
      modelJSON[optional]: model data in JSON format, any data not overwritten by the form will be added to the formData
@@ -24,7 +24,11 @@ module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData,
   if(form){
     form.addClass('formChecked');
     if (!form[0].checkValidity()){
-      messageModal.show(window.polyglot.t('errorMessages.saveError'), window.polyglot.t('errorMessages.missingError'));
+      if(typeof onInvalid === 'function'){
+        onInvalid();
+      } else {
+        messageModal.show(window.polyglot.t('errorMessages.saveError'), window.polyglot.t('errorMessages.missingError'));
+      }
       return $.Deferred().reject('failed form validation').promise();
     }
 

--- a/js/views/transactionModalVw.js
+++ b/js/views/transactionModalVw.js
@@ -203,13 +203,15 @@ module.exports = baseVw.extend({
         confirmData = {};
 
     confirmData.id = this.orderID;
-    this.$el.find('.js-transactionSpinner').removeClass('hide');
+    this.$('.js-transactionSpinner').removeClass('hide');
 
     saveToAPI(targetForm, '', this.serverUrl + "confirm_order", function(data){
       self.status = 2;
       self.tabState = "summary";
       self.getData();
-      }, '', confirmData);
+      }, '', confirmData, '', function(){
+      self.$('.js-transactionSpinner').addClass('hide');
+    });
   },
 
   completeOrder: function(e){

--- a/js/views/transactionModalVw.js
+++ b/js/views/transactionModalVw.js
@@ -327,10 +327,9 @@ module.exports = baseVw.extend({
     var messageInput = this.$('#transactionDiscussionSendText');
     var messageText = messageInput.val();
     var self = this;
+    var socketMessageId = Math.random().toString(36).slice(2);
     __.each(messages, function(msg){
       if (messageText) {
-        var socketMessageId = Math.random().toString(36).slice(2);
-
         var chatMessage = {
           "request": {
             "api": "v1",


### PR DESCRIPTION
- adds comments field to order confirmation
- changes shipping tab to show for all 3 listing types
- comments are shown in shipping tab
- change saveToAPI to add onInvalid parameter to pass a function to be executed if the form has an invalid field instead of the default behavior
