### PR TITLE
Server connect tweaks

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -182,7 +182,6 @@ form {
 }
 
 
-
 /*========== structure classes ==========*/
 
 #content {
@@ -4992,6 +4991,10 @@ input[type="checkbox"].fieldItem:checked + label .togLabelOff {
 
 #ov1 .alignCenter {
   text-align: center;
+}
+
+#ov1 .heightAuto {
+  height: auto;
 }
 
 /* terrible hack, TODO: remove before production */

--- a/js/App.js
+++ b/js/App.js
@@ -54,6 +54,17 @@ App.prototype.getHeartbeatSocket = function() {
   return this._heartbeatSocket;
 };
 
+App.prototype.login = function() {
+  return $.ajax({
+    url: this.serverConfig.getServerBaseUrl() + '/login',
+    method: 'POST',
+    data: {
+      username: this.serverConfig.get('username'),
+      password: this.serverConfig.get('password')
+    }
+  });  
+};
+
 App.getApp = function() {
   if (!_app) {
     throw new Error('The app instance was never instantiated and is therefore not available.');

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-var App = require('./App');
+var App = require('./App'),
     app = new App();
 
 var __ = window.__ = require('underscore'),
@@ -55,7 +55,6 @@ var Polyglot = require('node-polyglot'),
     startRemoteInitSequence,
     launchOnboarding,
     launchServerConnect,
-    login,
     setServerUrl,
     guidCreating;
 
@@ -185,16 +184,6 @@ var loadProfile = function(landingRoute) {
   });
 };
 
-$(document).ajaxSend(function(e, jqxhr, settings) {
-  var username = serverConfigMd.get('username'),
-      pw = serverConfigMd.get('password'),
-      serverBaseUrl = serverConfigMd.getServerBaseUrl();
-
-  if (username && pw && settings.url.startsWith(serverBaseUrl)) {
-    jqxhr.setRequestHeader('Authorization', 'Basic ' + btoa(username + ':' + pw));    
-  }
-});
-
 $(document).ajaxError(function(event, jqxhr, settings, thrownError) {
   if (jqxhr.status === 401) {
     launchServerConnect();
@@ -224,9 +213,7 @@ launchOnboarding = function(guidCreating) {
 
 launchServerConnect = function() {
   if (!serverConnectModal) {
-    serverConnectModal = new ServerConnectModal({
-      model: serverConfigMd
-    });
+    serverConnectModal = new ServerConnectModal();
 
     serverConnectModal.on('connected', function() {
       // clear some flags so the heartbeat events will
@@ -260,13 +247,6 @@ launchServerConnect = function() {
   }
 };
 
-login = function() {
-  return $.post(serverConfigMd.getServerBaseUrl() + '/login', {
-    username: serverConfigMd.get('username'),
-    password: serverConfigMd.get('password')
-  });
-}
-
 heartbeat.on('close', function(e) {
   // server down
   launchServerConnect();
@@ -291,7 +271,7 @@ heartbeat.on('message', function(e) {
           password: e.jsonData.password
         });
 
-        login().done(function() {
+        app.login().done(function() {
           guidCreating.resolve();
         });
 
@@ -300,14 +280,18 @@ heartbeat.on('message', function(e) {
         if (loadProfileNeeded && !guidCreating) {
           loadProfileNeeded = false;
 
-          login().done(function() {
-            $.getJSON(serverConfigMd.getServerBaseUrl() + '/profile').done(function(profile) {
-              if (__.isEmpty(profile)) {
-                launchOnboarding(guidCreating = $.Deferred().resolve().promise());
-              } else {
-                loadProfile();              
-              }
-            });
+          app.login().done(function(data) {
+            if (data.success) {
+              $.getJSON(serverConfigMd.getServerBaseUrl() + '/profile').done(function(profile) {
+                if (__.isEmpty(profile)) {
+                  launchOnboarding(guidCreating = $.Deferred().resolve().promise());
+                } else {
+                  loadProfile();              
+                }
+              });
+            } else {
+              launchServerConnect();
+            }
           });
         }
 

--- a/js/main.js
+++ b/js/main.js
@@ -223,9 +223,6 @@ launchServerConnect = function() {
 
       $loadingModal.removeClass('hide');      
 
-      // todo: perhaps only re-load if the server changed and on
-      // re-connect of the same server, just refresh the current
-      // route or let loadProfile happen if it hadn't already?
       if (profileLoaded) {
         location.reload();
       }

--- a/js/main.js
+++ b/js/main.js
@@ -289,6 +289,8 @@ heartbeat.on('message', function(e) {
             } else {
               launchServerConnect();
             }
+          }).fail(function() {
+            launchServerConnect();
           });
         }
 

--- a/js/models/languagesMd.js
+++ b/js/models/languagesMd.js
@@ -470,8 +470,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -922,8 +923,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -1384,8 +1386,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -1850,8 +1853,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -2317,8 +2321,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -2779,9 +2784,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
-          statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -3242,8 +3247,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -3704,8 +3710,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -4170,8 +4177,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -4635,8 +4643,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -5099,8 +5108,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -5566,8 +5576,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated
@@ -6016,8 +6027,9 @@ module.exports = Backbone.Model.extend({
           statusConnected: "Connected", //notTranslated
           statusFailedConnection: "Unable to connect to your server", //notTranslated
           statusFailedAuthentication: "Authentication failed", //notTranslated
+          statusTooManyAttempts: "Too many failed login attempts", //notTranslated
           serverConfiguration: "Server Configuration", //notTranslated
-          attempt: "Attempt", //notTranslated
+          connecting: "Connecting", //notTranslated
           intro: "OpenBazaar is designed to allow you to host your server separate from the client. By default, your server will run locally, but you can override it below.", //notTranslated
           serverIP: "Server IP", //notTranslated
           restApiPort: "Rest API port", //notTranslated

--- a/js/models/serverConfigMd.js
+++ b/js/models/serverConfigMd.js
@@ -100,6 +100,14 @@ module.exports = Backbone.Model.extend({
       }
     }    
 
+    if (is.empty(attrs.username)) {
+      this._addError(err, 'username', 'Please provide a value.');
+    }
+
+    if (is.empty(attrs.password)) {
+      this._addError(err, 'password', 'Please provide a value.');
+    }    
+
     return Object.keys(err).length && err || undefined;
   },
 

--- a/js/templates/changeServerWarningModal.html
+++ b/js/templates/changeServerWarningModal.html
@@ -1,0 +1,10 @@
+<h1>Please Note Settings</h1>
+<p>We noticed you have changed your settings. Below, we have ouptut the previous values. It is recommended that you store them in case you want to re-connect using them. Some of the settings (notably username &amp; password) will no longer be available beyond this point.</p>
+<ul class="padding0">
+  <li class="list-style-none">Server IP: <%= ob.server_ip %></li>
+  <li class="list-style-none">Rest API Port: <%= ob.rest_api_port %></li>
+  <li class="list-style-none">Websocket API Port: <%= ob.api_socket_port %></li>
+  <li class="list-style-none">Heartbeat Socket Port: <%= ob.heartbeat_socket_port %></li>
+  <li class="list-style-none">Username: <%= ob.username %></li>
+  <li class="list-style-none">Password: <%= ob.password %></li>
+</ul>

--- a/js/templates/serverConnectModal.html
+++ b/js/templates/serverConnectModal.html
@@ -8,6 +8,8 @@
     <p class="h6 homeModal-heroText fancy-heading"><%= polyglot.t('serverConnectModal.statusFailedConnection') %>.</p>
   <% } else if (ob.status == 'failed-auth') { %>  
     <p class="h6 homeModal-heroText fancy-heading"><%= polyglot.t('serverConnectModal.statusFailedAuthentication') %>.</p>
+  <% } else if (ob.status == 'failed-auth-too-many') { %>  
+    <p class="h6 homeModal-heroText fancy-heading"><%= polyglot.t('serverConnectModal.statusTooManyAttempts') %>.</p>
   <% } %>
   </p>
 </div>
@@ -17,9 +19,7 @@
       <%= polyglot.t('serverConnectModal.serverConfiguration') %>
       <span class="textOpacity75 fontSize14 floatRight">
         <% if (ob.status == 'trying') { %>
-          <!-- variablize the max attempts -->
-          <i class="ion-android-sync spinner"></i>
-          <%= polyglot.t('serverConnectModal.attempt') %> <span class="attempt"></span> <%= polyglot.t('of') %> 3
+          <i class="ion-android-sync spinner"></i> <%= polyglot.t('serverConnectModal.connecting') %>...
         <% } else if (ob.status === 'failed' || ob.status === 'failed-auth') { %>
         <a class="js-retry"><%= polyglot.t('serverConnectModal.retry') %></a>
         <% } %>

--- a/js/templates/serverConnectModal.html
+++ b/js/templates/serverConnectModal.html
@@ -33,7 +33,7 @@
           <div class="flexCol-12 flex-border borderBottom">
             <div class="flexRow">
               <% if (ob.errors.server_ip) { %>
-              <div class="flexCol-12">
+              <div class="flexCol-12 error">
                 <ul class="padding2015">
                   <% ob.errors.server_ip.forEach(function(err) {
                        print('<li class="list-style-none">' + err + '</li>');

--- a/js/views/changeServerWarningModal.js
+++ b/js/views/changeServerWarningModal.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var __ = require('underscore'),
+    Backbone = require('backbone'),
+    loadTemplate = require('../utils/loadTemplate'),
+    baseModal = require('./baseModal');
+
+module.exports = baseModal.extend({
+  className: 'change-server-warning-modal',
+
+  events: {
+    'click button': 'okClick'
+  },
+
+  initialize: function(options) {
+    if (!options.model) {
+      throw new Error('Please provide a Server Config model.');
+    }
+  },
+
+  okClick: function() {
+    this.close();
+  },
+
+  render: function() {
+    var self = this;
+
+    loadTemplate('./js/templates/changeServerWarningModal.html', function(t) {
+      self.$el.html(t( self.model.toJSON() ));
+
+      baseModal.prototype.render.apply(self, arguments);
+    });
+
+    return this;
+  }
+});

--- a/js/views/changeServerWarningModal.js
+++ b/js/views/changeServerWarningModal.js
@@ -13,8 +13,10 @@ module.exports = baseModal.extend({
   },
 
   initialize: function(options) {
-    if (!options.model) {
-      throw new Error('Please provide a Server Config model.');
+    this.options = options || {};
+    
+    if (!options.settings) {
+      throw new Error('Please provide an object with the server settings.');
     }
   },
 
@@ -26,7 +28,7 @@ module.exports = baseModal.extend({
     var self = this;
 
     loadTemplate('./js/templates/changeServerWarningModal.html', function(t) {
-      self.$el.html(t( self.model.toJSON() ));
+      self.$el.html(t( self.options.settings ));
 
       baseModal.prototype.render.apply(self, arguments);
     });

--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -28,6 +28,8 @@ module.exports = baseModal.extend({
     this._state = {
       status: 'trying'
     };
+
+    this._lastSavedAttrs = $.extend(true, {}, this.model.attributes);
   },
 
   inputEntered: function(e) {
@@ -40,10 +42,11 @@ module.exports = baseModal.extend({
         this.changeServerWarningModal = new ChangeServerWarningModal({
           innerWrapperClass: 'modal-child modal-childMain custCol-primary padding2010 heightAuto',
           includeCloseButton: true,
-          model: this.model
+          settings: this._lastSavedAttrs
         }).render().open();
         
         this.listenTo(this.changeServerWarningModal, 'close', function() {
+          this._lastSavedAttrs = $.extend(true, {}, this.model.attributes);
           this.start();
         });
       } else {

--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -25,17 +25,9 @@ module.exports = baseModal.extend({
       this.render();
     });
 
-    this._state = this.getInitialState();
-    this._lastSavedAttrs = $.extend(true, {}, this.model.attributes);
-  },
-
-  getInitialState: function() {
-    var state = {};
-
-    state['attempt'] = 1;
-    state['status'] = 'trying';
-
-    return state;
+    this._state = {
+      status: 'trying'
+    };
   },
 
   inputEntered: function(e) {
@@ -43,10 +35,6 @@ module.exports = baseModal.extend({
   },
 
   saveForm: function() {
-    if (__.isEqual(this.model.attributes, this._lastSavedAttrs)) {
-      return;
-    }
-
     if (this.model.save()) {
       if (!this.changeServerWarningModal) {
         this.changeServerWarningModal = new ChangeServerWarningModal({
@@ -56,7 +44,6 @@ module.exports = baseModal.extend({
         }).render().open();
         
         this.listenTo(this.changeServerWarningModal, 'close', function() {
-          this._lastSavedAttrs = $.extend(true, {}, this.model.attributes);
           this.start();
         });
       } else {
@@ -75,20 +62,11 @@ module.exports = baseModal.extend({
   setState: function(state) {
     var newState;
     
-    if (typeof state['attempt'] !== 'undefined') {
-      this.$attempt.text(state['attempt']);
-    }
-
     newState =  __.extend({}, this._state, state);
 
     if (!__.isEqual(this._state, newState)) {
       this._state = newState;
-
-      if (!(typeof state['attempt'] !== 'undefined' && Object.keys(state).length === 1)) {
-        // if the only new state is the attemp counter, no need to
-        // re-render since we manually updated that above.
-        this.render();
-      }
+      this.render();
     }
   },
 
@@ -188,11 +166,7 @@ module.exports = baseModal.extend({
 
     this.connectAttempt && this.connectAttempt.cancel();
 
-    this.setState(
-      __.extend(this.getInitialState(), {
-        status: 'trying'
-      })
-    );
+    this.setState({ status: 'trying' });
 
     (connect = function() {
       self.connectAttempt = self.attemptConnection().done(function() {
@@ -254,7 +228,6 @@ module.exports = baseModal.extend({
 
       baseModal.prototype.render.apply(self, arguments);
       self.$('.flexContainer.scrollOverflowYHideX')[0].scrollTop = scrollPos;
-      self.$attempt = self.$('.attempt').text(self._state.attempt);
     });
 
     return this;


### PR DESCRIPTION
This PR accomplishes a few things, notably:

1.) When changing the server settings, the new creds will be POSTed to the login api.
2.) If the login api fails because of too many failed attempts, the modal will indicate so. At the point, the user will need to wait an hour or re-start their server or connect to a different server.
3.) When settings are saved, a modal pops up with the previous settings, urging the user to store the previous setting so, if desired, they can revert back to them.
