### PR TITLE
tweaks to server connect

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -26,13 +26,6 @@ function App() {
 App.prototype.connectHeartbeatSocket = function() {
   var self = this;
 
-  // todo: check if socket is already connected to the url specified in
-  // the config and if so, just return;
-
-  // if (this._heartbeatSocket && this._heartbeatSocket.getReadyState() <= 1) {
-  //   return;
-  // }
-
   clearTimeout(this.heartbeatSocketTimesup);
 
   if (this._heartbeatSocket) {
@@ -43,14 +36,14 @@ App.prototype.connectHeartbeatSocket = function() {
     this._heartbeatSocket.on('close', function() {
       clearTimeout(self._heartbeatSocketTimesup);
     });
-
-    // give up if it takes to long
-    this._heartbeatSocketTimesup = setTimeout(function() {
-      if (self._heartbeatSocket.getReadyState() !== 1) {
-        self._heartbeatSocket._socket.close();
-      }
-    }, 3000);    
   }
+
+  // give up if it takes to long
+  this._heartbeatSocketTimesup = setTimeout(function() {
+    if (self._heartbeatSocket.getReadyState() !== 1) {
+      self._heartbeatSocket._socket.close();
+    }
+  }, 3000);  
 };
 
 App.prototype.getHeartbeatSocket = function() {

--- a/js/utils/Socket.js
+++ b/js/utils/Socket.js
@@ -15,6 +15,11 @@ function Socket(url) {
 Socket.prototype.connect = function(url) {
   var self = this;
 
+  // if already connected, do nothing
+  if (url === this.url && this._socket && this._socket.readyState <= 1) {
+    return;
+  }
+
   this.url = url || this.url;
 
   if (this._socket) {

--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -169,7 +169,7 @@ module.exports = baseModal.extend({
         if (reason == 'canceled') return;
         
         if (attempts >= 3 || reason === 'failed-auth' || reason === 'failed-auth-too-many') {
-          self.setState({ status: reason || 'failed' });
+          self.setState({ status: reason === 'failed-auth' ? 'failed-auth' : 'failed' });
         } else {
           attempts += 1;
           connect();


### PR DESCRIPTION
Couple of tweaks to server connect functionality:

1.) Avoid duplicate socket connections.
2.) On socket timeout (was happening on unreachable servers with a remote url), properly display failed connection state on the Server Connect modal (the messaging had been blank in the case of a timeout).
