### PR TITLE
SSL setting in config server

### DIFF
--- a/js/models/languagesMd.js
+++ b/js/models/languagesMd.js
@@ -259,6 +259,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",
         ShutDownServer: "Shut Down the Server",
         LoadingBitcoinPrices: "Loading Bitcoin Prices...",
+        ServerChangeWarningHeadline: "Caution: Record Your Settings",
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.",
         moderatorSettings: {
           DisputeResolution: "Dispute Resolution",
           ServiceFee: "Service fee",
@@ -748,6 +750,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -1234,6 +1238,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -1724,6 +1730,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -2214,6 +2222,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Paramètres du serveur",
         ShutDownServer: "Arrêter le serveur",
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: {
           DisputeResolution: "Résolution de litige",
           ServiceFee: "Frais de service",
@@ -2702,6 +2712,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -3188,6 +3200,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -3674,6 +3688,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -4164,6 +4180,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -4653,6 +4671,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -5142,6 +5162,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -5632,6 +5654,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -6107,6 +6131,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: { // not translated
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee", // not translated
@@ -6596,6 +6622,8 @@ module.exports = Backbone.Model.extend({
         ServerSettings: "Server Settings",  // not translated
         ShutDownServer: "Shut Down the Server",  // not translated
         LoadingBitcoinPrices: "Loading Bitcoin Prices...", // not translated
+        ServerChangeWarningHeadline: "Caution: Record Your Settings", // not translated
+        ServerChangeWarning: "We recommend you make a copy of your previous settings, shown below. Your previous username and password will no longer be available beyond this point.", // not translated
         moderatorSettings: {
           DisputeResolution: "Dispute Resolution", //notTranslated
           ServiceFee: "Service fee",//notTranslated

--- a/js/models/serverConfigMd.js
+++ b/js/models/serverConfigMd.js
@@ -8,7 +8,8 @@ module.exports = Backbone.Model.extend({
     'server_ip': 'localhost',
     'rest_api_port': 18469,
     'api_socket_port': 18466,
-    'heartbeat_socket_port': 18470
+    'heartbeat_socket_port': 18470,
+    'SSL': false
   },
 
   sync: localStorageSync.sync,
@@ -112,7 +113,8 @@ module.exports = Backbone.Model.extend({
   },
 
   getServerBaseUrl: function() {
-    return 'http://' + this.get('server_ip') + ':' + this.get('rest_api_port') + '/api/v1';
+    var prefix = this.get('SSL') ? "https" : "http";
+    return prefix + '://' + this.get('server_ip') + ':' + this.get('rest_api_port') + '/api/v1';
   },
 
   getHeartbeatSocketUrl: function() {

--- a/js/templates/changeServerWarningModal.html
+++ b/js/templates/changeServerWarningModal.html
@@ -1,5 +1,5 @@
-<h1>Please Note Settings</h1>
-<p>We noticed you have changed your settings. Below, we have ouptut the previous values. It is recommended that you store them in case you want to re-connect using them. Some of the settings (notably username &amp; password) will no longer be available beyond this point.</p>
+<h1><%= polyglot.t('ServerChangeWarningHeadline') %></h1>
+<p><%= polyglot.t('ServerChangeWarning') %></p>
 <ul class="padding0">
   <li class="list-style-none">Server IP: <%= ob.server_ip %></li>
   <li class="list-style-none">Rest API Port: <%= ob.rest_api_port %></li>

--- a/js/templates/serverConnectModal.html
+++ b/js/templates/serverConnectModal.html
@@ -32,7 +32,7 @@
       <div class="flexRow borderBottom custCol-border">
         <p class="margin0 padding2015 textOpacity75"><%= polyglot.t('serverConnectModal.intro') %></p>
       </div>
-        <form class="width100" name="serverConfigForm">
+        <form class="width100 <% if (ob.status == 'trying') { %>disabled<% } %>" name="serverConfigForm">
           <div class="flexCol-12 flex-border borderBottom">
             <div class="flexRow">
               <% if (ob.errors.server_ip) { %>
@@ -53,6 +53,16 @@
 
               <div class="flexCol-8 borderRight0 custCol-border <% ob.errors.server_ip && print('invalid') %>">
                 <input name="server_ip" type="text" id="fld_server" placeholder="" class="fieldItem" required="" value="<%= ob.server_ip %>">
+                <div class="btn btn-txt btn-corner btn-cornerTR custCol-secondary ion-locked
+                            positionAbsolute tooltip <% if(!ob.SSL){ %> hide <% } %>  js-sslOn"
+                     data-tooltip="SSL is on">
+                  SSL on
+                </div>
+                <div class="btn btn-txt btn-corner btn-cornerTR custCol-secondary ion-unlocked
+                            positionAbsolute tooltip <% if(ob.SSL){ %> hide <% } %>  js-sslOff"
+                     data-tooltip="SSL is off">
+                  SSL off
+                </div>
               </div>
             </div>
 
@@ -169,7 +179,7 @@
         </form>
     </div>
 
-    <div class="bar barFlush borderBottomLeftRaidus3 color-secondary custCol-secondary borderBottomRightRaidus3">
+    <div class="bar barFlush borderBottomLeftRaidus3 color-secondary custCol-secondary borderBottomRightRaidus3 <% if (ob.status == 'trying') { %>disabled<% } %>">
       <a class="btn btn-bar btn-half js-restoreDefaults color-secondary custCol-secondary custCol-border-primary custCol-text textOpacity90 borderRight" tabindex="0">
         <span class="fontSize10 marginRight2"></span>
         <%= polyglot.t('serverConnectModal.restoreDefaults') %>

--- a/js/templates/settings.html
+++ b/js/templates/settings.html
@@ -1088,36 +1088,6 @@
               <div class="flexCol-3  borderRight custCol-border">
                 <div class="fieldItem">
                   <label>
-                    <%= polyglot.t('EnableSSL') %>
-                  </label>
-                </div>
-              </div>
-
-              <div class="flexCol-9 borderRight0 custCol-border">
-                <div class="fieldItem">
-                  <input type="radio" class="fieldItem" id="sslYes" name="ssl" value="true"
-                    <% if(ob.user.ssl) { %>
-                    checked
-                    <% } %>
-                  />
-                  <label for="sslYes" class="radioLabel"><%= polyglot.t('Yes') %></label>
-                  <input type="radio" class="fieldItem" id="sslNo" name="ssl" value="false"
-                    <% if(!ob.user.ssl) { %>
-                    checked
-                    <% } %>
-                  />
-                  <label for="sslNo" class="radioLabel"><%= polyglot.t('No') %></label>
-
-                </div>
-              </div>
-
-            </div>
-
-            <div class="flexRow">
-
-              <div class="flexCol-3  borderRight custCol-border">
-                <div class="fieldItem">
-                  <label>
                     <%= polyglot.t('Firewall') %>
                   </label>
                 </div>

--- a/js/views/baseModal.js
+++ b/js/views/baseModal.js
@@ -16,7 +16,7 @@ module.exports = baseVw.extend({
         includeCloseButton: false,
         closeButtonClass: 'btn-corner btn-cornerTR',
         innerWrapperClass: 'modal-child modal-childMain custCol-primary'
-      }
+      };
 
       this.__options = __.extend({}, defaults, options || {});
       this.className = 'modal modal-opaque ' + __.result(this, 'className', '');

--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -27,7 +27,6 @@ module.exports = baseModal.extend({
     });
 
     this.listenTo(this.model, 'change:SSL', function() {
-      console.log("change")
       this.render();
     });
 
@@ -200,7 +199,6 @@ module.exports = baseModal.extend({
   },
 
   sslOff: function(){
-    console.log("click")
     this.model.set('SSL', true);
   },
 

--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -14,7 +14,9 @@ module.exports = baseModal.extend({
     'click .js-save': 'saveForm',
     'click .js-restoreDefaults': 'restoreDefaults',
     'input input': 'inputEntered',
-    'click .js-retry': 'retry'
+    'click .js-retry': 'retry',
+    'click .js-sslOn': 'sslOn',
+    'click .js-sslOff': 'sslOff'
   },
 
   initialize: function(options) {
@@ -47,7 +49,7 @@ module.exports = baseModal.extend({
       } else {
         this.changeServerWarningModal.open();
       }
-    };
+    }
   },
 
   restoreDefaults: function() {
@@ -128,7 +130,7 @@ module.exports = baseModal.extend({
 
     promise.cancel = function() {
       deferred.reject('canceled');
-    }
+    };
 
     promise.always(function() {
       promise.cleanup();
@@ -186,6 +188,18 @@ module.exports = baseModal.extend({
       this.connectAttempt = null;
       this.setState({ status: 'failed' });
     }
+  },
+
+  sslOn: function(){
+    this.model.set('SSL', false);
+    this.$('.js-sslOn').addClass('hide');
+    this.$('.js-sslOff').removeClass('hide');
+  },
+
+  sslOff: function(){
+    this.model.set('SSL', true);
+    this.$('.js-sslOn').removeClass('hide');
+    this.$('.js-sslOff').addClass('hide');
   },
 
   isStarted: function() {

--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -26,6 +26,11 @@ module.exports = baseModal.extend({
       this.render();
     });
 
+    this.listenTo(this.model, 'change:SSL', function() {
+      console.log("change")
+      this.render();
+    });
+
     this._lastSavedAttrs = $.extend(true, {}, this.model.attributes);
   },
 
@@ -192,14 +197,11 @@ module.exports = baseModal.extend({
 
   sslOn: function(){
     this.model.set('SSL', false);
-    this.$('.js-sslOn').addClass('hide');
-    this.$('.js-sslOff').removeClass('hide');
   },
 
   sslOff: function(){
+    console.log("click")
     this.model.set('SSL', true);
-    this.$('.js-sslOn').removeClass('hide');
-    this.$('.js-sslOff').addClass('hide');
   },
 
   isStarted: function() {


### PR DESCRIPTION
- removes unused SSL toggle from the advanced Settings tab
- adds a SSL toggle to the server config modal
- disables the controls on the config modal while it is connected. This prevents an issue where multiple connecting loops start, and the client reloads multiple times and eventually gets locked on the loading screen.
