### PR TITLE
Server connect tweaks

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -57,7 +57,8 @@ App.prototype.login = function() {
     data: {
       username: this.serverConfig.get('username'),
       password: this.serverConfig.get('password')
-    }
+    },
+    timeout: 3000
   });  
 };
 

--- a/js/main.js
+++ b/js/main.js
@@ -230,7 +230,7 @@ launchServerConnect = function() {
   if (!serverConnectModal) {
     serverConnectModal = new ServerConnectModal();
 
-    serverConnectModal.on('connected', function() {
+    serverConnectModal.on('connected', function(authenticated) {
       // clear some flags so the heartbeat events will
       // appropriatally loadProfile or launch onboarding
       guidCreating = null;
@@ -241,12 +241,12 @@ launchServerConnect = function() {
       if (profileLoaded) {
         location.reload();
       }
-    });
 
-    serverConnectModal.on('authenticated', function() {
-      serverConnectModal && serverConnectModal.remove();
-      serverConnectModal = null;
-    });    
+      if (authenticated) {
+        serverConnectModal && serverConnectModal.remove();
+        serverConnectModal = null;        
+      }
+    });
 
     serverConnectModal.render()
       .open()

--- a/js/templates/serverConnectModal.html
+++ b/js/templates/serverConnectModal.html
@@ -3,7 +3,7 @@
   <% if (ob.status == 'trying') { %>
     <p class="h6 homeModal-heroText fancy-heading"><%= polyglot.t('serverConnectModal.statusTryingToConnect') %>...</p>
   <% } else if (ob.status == 'connected') { %>
-    <p class="h6 homeModal-heroText fancy-heading"><%= polyglot.t('serverConnectModal.statusConnected') %>./p>  
+    <p class="h6 homeModal-heroText fancy-heading"><%= polyglot.t('serverConnectModal.statusConnected') %>.</p>  
   <% } else if (ob.status == 'failed') { %>  
     <p class="h6 homeModal-heroText fancy-heading"><%= polyglot.t('serverConnectModal.statusFailedConnection') %></p>
   <% } else if (ob.status == 'failed-auth') { %>  
@@ -32,7 +32,7 @@
       <div class="flexRow borderBottom custCol-border">
         <p class="margin0 padding2015 textOpacity75"><%= polyglot.t('serverConnectModal.intro') %></p>
       </div>
-        <form class="width100 <% if (ob.status == 'bbbbbtrying') { %>disabled<% } %>" name="serverConfigForm">
+        <form class="width100" name="serverConfigForm">
           <div class="flexCol-12 flex-border borderBottom">
             <div class="flexRow">
               <% if (ob.errors.server_ip) { %>
@@ -179,7 +179,7 @@
         </form>
     </div>
 
-    <div class="bar barFlush borderBottomLeftRaidus3 color-secondary custCol-secondary borderBottomRightRaidus3 <% if (ob.status == 'bbbbbbtrying') { %>disabled<% } %>">
+    <div class="bar barFlush borderBottomLeftRaidus3 color-secondary custCol-secondary borderBottomRightRaidus3">
       <a class="btn btn-bar btn-half js-restoreDefaults color-secondary custCol-secondary custCol-border-primary custCol-text textOpacity90 borderRight" tabindex="0">
         <span class="fontSize10 marginRight2"></span>
         <%= polyglot.t('serverConnectModal.restoreDefaults') %>

--- a/js/templates/serverConnectModal.html
+++ b/js/templates/serverConnectModal.html
@@ -32,7 +32,7 @@
       <div class="flexRow borderBottom custCol-border">
         <p class="margin0 padding2015 textOpacity75"><%= polyglot.t('serverConnectModal.intro') %></p>
       </div>
-        <form class="width100 <% if (ob.status == 'trying') { %>disabled<% } %>" name="serverConfigForm">
+        <form class="width100 <% if (ob.status == 'bbbbbtrying') { %>disabled<% } %>" name="serverConfigForm">
           <div class="flexCol-12 flex-border borderBottom">
             <div class="flexRow">
               <% if (ob.errors.server_ip) { %>
@@ -179,7 +179,7 @@
         </form>
     </div>
 
-    <div class="bar barFlush borderBottomLeftRaidus3 color-secondary custCol-secondary borderBottomRightRaidus3 <% if (ob.status == 'trying') { %>disabled<% } %>">
+    <div class="bar barFlush borderBottomLeftRaidus3 color-secondary custCol-secondary borderBottomRightRaidus3 <% if (ob.status == 'bbbbbbtrying') { %>disabled<% } %>">
       <a class="btn btn-bar btn-half js-restoreDefaults color-secondary custCol-secondary custCol-border-primary custCol-text textOpacity90 borderRight" tabindex="0">
         <span class="fontSize10 marginRight2"></span>
         <%= polyglot.t('serverConnectModal.restoreDefaults') %>

--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -20,6 +20,7 @@ module.exports = baseModal.extend({
   },
 
   initialize: function(options) {
+    this.options = options || {};
     this.model = app.serverConfig;
 
     this.listenTo(this.model, 'invalid sync', function() {
@@ -30,6 +31,7 @@ module.exports = baseModal.extend({
       this.render();
     });
 
+    this._state = this.options.initialState || {};
     this._lastSavedAttrs = $.extend(true, {}, this.model.attributes);
   },
 
@@ -97,20 +99,19 @@ module.exports = baseModal.extend({
     };
 
     login = function() {
-      // at this point, we've confirmed connection, so:
-      self.trigger('connected');
-
       // check authentication
       loginRequest = app.login().done(function(data) {
         if (data.success) {
           deferred.resolve();
-          self.trigger('authenticated');
+          self.trigger('connected', true);
         } else {
           if (data.reason === 'too many attempts') {
             rejectLogin('failed-auth-too-many');  
           } else {
             rejectLogin('failed-auth');  
-          }          
+          }
+
+          self.trigger('connected', false);
         }
       }).fail(function(jqxhr) {
         if (jqxhr.statusText === 'abort') return;
@@ -172,7 +173,7 @@ module.exports = baseModal.extend({
     }).fail(function(reason) {
       if (reason == 'canceled') return;
 
-      self.setState({ status: typeof reason === undefined || reason === 'timedout' ? 'failed' : reason });
+      self.setState({ status: typeof reason === 'undefined' || reason === 'timedout' ? 'failed' : reason });
     }).always(function() {
       self.connectAttempt = null;
     });

--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -165,25 +165,17 @@ module.exports = baseModal.extend({
         connect;
 
     this.connectAttempt && this.connectAttempt.cancel();
-
     this.setState({ status: 'trying' });
 
-    (connect = function() {
-      self.connectAttempt = self.attemptConnection().done(function() {
-        self.setState({ status: 'connected' });
-      }).fail(function(reason) {
-        if (reason == 'canceled') return;
-        
-        if (attempts >= 3 || reason === 'failed-auth' || reason === 'failed-auth-too-many') {
-          self.setState({ status: reason === 'failed-auth' ? 'failed-auth' : 'failed' });
-        } else {
-          attempts += 1;
-          connect();
-        }
-      }).always(function() {
-        self.connectAttempt = null;
-      });
-    })();
+    this.connectAttempt = this.attemptConnection().done(function() {
+      self.setState({ status: 'connected' });
+    }).fail(function(reason) {
+      if (reason == 'canceled') return;
+
+      self.setState({ status: typeof reason === undefined || reason === 'timedout' ? 'failed' : reason });
+    }).always(function() {
+      self.connectAttempt = null;
+    });
   },
 
   stop: function() {

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -791,7 +791,10 @@ module.exports = Backbone.View.extend({
 
   launchServerConfig: function() {
     var serverConnectModal = new ServerConnectModal({
-      includeCloseButton: true
+      includeCloseButton: true,
+      initialState: {
+        status: 'connected'
+      }
     }).render().open();
 
     this.serverConnectSyncHandler &&


### PR DESCRIPTION
another round of obscure connect related bug fixes:

1.) Fixed the issue of multiple connection attempts queuing up rather than one being cancelled before attempting the next. This allowed me to remove the code that disables the form while a connect attempt is in progress.

2.) Fixed issue where upon turning on the SSL flag, the app would restart (thinking it was successfully connected) and then subsequently fail to connect. Now, it will only re-start if it truly successfully connects.
