### PR TITLE
Configurable data path

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ safestart(__dirname);
 
 var fs = require('fs');
 var path = require('path');
+var argv = require('yargs').argv;
 
 var app = require('app');  // Module to control application life.
 var electron = require('electron');
@@ -29,6 +30,15 @@ var trayMenu = null;
 var subpy = null;
 
 var open_url = null; // This is for if someone opens a URL before the client is open
+
+if (argv.appData) {
+  try {
+    app.setPath('appData', argv.appData);
+    app.setPath('userData', argv.appData);
+  } catch (e) {
+    throw new Error('The passed in appData directory does not appear to be valid: ' + e);
+  }
+}
 
 var handleStartupEvent = function() {
   if (process.platform !== 'win32') {

--- a/main.js
+++ b/main.js
@@ -31,12 +31,11 @@ var subpy = null;
 
 var open_url = null; // This is for if someone opens a URL before the client is open
 
-if (argv.appData) {
+if (argv.userData) {
   try {
-    app.setPath('appData', argv.appData);
-    app.setPath('userData', argv.appData);
+    app.setPath('userData', argv.userData);
   } catch (e) {
-    throw new Error('The passed in appData directory does not appear to be valid: ' + e);
+    throw new Error('The passed in userData directory does not appear to be valid: ' + e);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "backbone.localstorage": "^1.1.16",
     "chosen": "0.0.2",
     "cropit": "0.4.5",
+    "ini": "^1.3.4",
     "is_js": "0.7.4",
     "jquery": "2.1.4",
     "jquery-colorbox": "^1.6.3",
@@ -36,7 +37,7 @@
     "sanitize-html": "^1.11.2",
     "taggle": "1.6.1",
     "underscore": "1.8.3",
-    "ini": "^1.3.4"
+    "yargs": "^4.1.0"
   },
   "devDependencies": {
     "electron-prebuilt": "0.36.2",


### PR DESCRIPTION
This PR allows you to configure the userData directory that Electron uses to store user specific data (e.g. localStorage). What this allows you to do is to run multiple clients on the same machine specifying different data directories for each one. Without it, they would all share the same localStorage and then you can't simultaneously have each client be connect to a different server.

I imagine this could be useful to others... It's really useful for me in that it allows me to have a local server running, a second server running in the cloud and two separate clients running on my box connecting to them. Saves me from having to run a local VM.

Anyhow, to pass in the new option, you'll need to start the client directly via electron, rather than via `npm start`, e.g.:

`./node_modules/.bin/electron main.js --userData /Users/rob/Library/ob-client-2`
