### PR TITLE
Various fixes2

### DIFF
--- a/js/templates/itemEdit.html
+++ b/js/templates/itemEdit.html
@@ -97,14 +97,14 @@
               <input type="text" name="currency_code" id="inputCurrencyCode" class="hide" />
               <input type="number" name="priceLocal" step="any" class="fieldItem js-priceLocal custCol-text"  id="priceLocal" value="<%= ob.price %>" required
                 <% if(ob.userCurrencyCode == "BTC"){ %>
-                min="0.0001"
+                min="0.0015"
                 <% } else { %>
-                min="<% print((window.currentBitcoin * 0.0005).toFixed(2)) %>"
+                min="<% print((window.currentBitcoin * 0.002).toFixed(2)) %>"
                 <% } %>
               >
             </div>
             <div class="flexCol-4">
-              <span class="fieldItem txt-placeholder">Minimum is <%= ob.userCurrencyCode == "BTC" ? 0.0001 :  (window.currentBitcoin * 0.0005).toFixed(2) %></span>
+              <span class="fieldItem txt-placeholder">Minimum is <%= ob.userCurrencyCode == "BTC" ? 0.0015 :  (window.currentBitcoin * 0.002).toFixed(2) %></span>
             </div>
           </div>
           <div class="flexRow custCol-border js-shippingRow">

--- a/js/templates/onboardingModal.html
+++ b/js/templates/onboardingModal.html
@@ -519,7 +519,7 @@
             <div class="statusBar navBar fadeOut positionAbsolute js-avatarLoading">
               <div class="pad20 rowTop20 width100"><h4 class="txt-center"><%= polyglot.t('LoadingImage') %></h4></div>
             </div>
-            <div class="cropit-image-preview rowTop10 thumbnail thumbnail-huge border1 row10"></div>
+            <div class="cropit-image-preview js-onboardingAvatarPreview rowTop10 thumbnail thumbnail-huge border1 row10"></div>
             <div>
               <input type="range" class="cropit-image-zoom-input rowTop10 row10 width100" />
             </div>

--- a/js/views/buyWizardVw.js
+++ b/js/views/buyWizardVw.js
@@ -459,7 +459,8 @@ module.exports = Backbone.View.extend({
         if(data.success == true){
           self.showPayAddress(data);
         } else {
-          messageModal.show(window.polyglot.t('errorMessages.contractError'), window.polyglot.t('errorMessages.sellerError') +" " + window.polyglot.t('errorMessages.checkPurchaseData'));
+          messageModal.show(window.polyglot.t('errorMessages.contractError'), window.polyglot.t('errorMessages.sellerError') +" " +
+              window.polyglot.t('errorMessages.checkPurchaseData') + "\n\n Reason: " + data.reason);
           self.$el.find('.js-buyWizardSpinner').addClass('hide');
         }
       },

--- a/js/views/onboardingModal.js
+++ b/js/views/onboardingModal.js
@@ -116,7 +116,8 @@ module.exports = baseModal.extend({
     var countryList,
         currencyList,
         timeList,
-        languageList;
+        languageList,
+        self = this;
 
     this._accordianReady = true;
     this.loadingOff();
@@ -137,9 +138,17 @@ module.exports = baseModal.extend({
     });
 
     this.$el.find('#image-cropper').cropit({
+      $preview: self.$('.js-onboardingAvatarPreview'),
+      $fileInput: self.$('#onboardingAvatarInput'),
       smallImage: "stretch",
       exportZoom: 1.33,
       maxZoom: 5,
+      onImageLoading: function(){
+        self.$el.find('.js-avatarLoading').removeClass('fadeOut');
+      },
+      onImageLoaded: function(){
+        self.$el.find('.js-avatarLoading').addClass('fadeOut');
+      },
       onFileReaderError: function(data){console.log(data);},
       onImageError: function(errorObject, errorCode, errorMessage) {
         console.log(errorObject);

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -4,7 +4,7 @@ var __ = require('underscore'),
     //userProfileModel = require('../models/userProfileMd'),
     loadTemplate = require('../utils/loadTemplate'),
     domUtils = require('../utils/dom'),
-    app = require('../App.js').getApp(),    
+    app = require('../App.js').getApp(),
     timezonesModel = require('../models/timezonesMd'),
     languagesModel = require('../models/languagesMd.js'),
     usersCl = require('../collections/usersCl.js'),
@@ -61,9 +61,9 @@ module.exports = Backbone.View.extend({
     var self = this;
     this.options = options || {};
     /* expected options:
-       userModel
-       state
-       socketView
+     userModel
+     state
+     socketView
      */
     this.socketView = options.socketView;
     this.userProfile = options.userProfile;
@@ -127,9 +127,7 @@ module.exports = Backbone.View.extend({
       self.setFormValues();
 
       self.newAvatar = false;
-      self.avatarNeverLoaded = true;
       self.newBanner = false;
-      self.bannerNeverLoaded = true;
 
       // Since the Blocked Users View kicks off many server calls (one
       // for each blocked user) and since we are re-rendering the entire
@@ -146,21 +144,18 @@ module.exports = Backbone.View.extend({
 
       $(".chosen").chosen({ width: '100%' });
       $('#settings-image-cropper').cropit({
-        $preview: $('.js-settingsAvatarPreview'),
-        $fileInput: $('#settingsAvatarInput'),
+        $preview: self.$('.js-settingsAvatarPreview'),
+        $fileInput: self.$('#settingsAvatarInput'),
         smallImage: "stretch",
         maxZoom: 2,
         onFileReaderError: function(data){console.log(data);},
         onImageLoading: function(){
-          self.$el.find('.js-avatarLoading').removeClass('fadeOut');
-          
-          if (self.avatarNeverLoaded) {
-            self.avatarNeverLoaded = false;
-          } else {
-            self.newAvatar = true;
-          }
+          self.newAvatar = true;
+          self.$('.js-avatarLoading').removeClass('fadeOut');
         },
-        onImageLoaded: function(){self.$el.find('.js-avatarLoading').addClass('fadeOut');},
+        onImageLoaded: function(){
+          self.$('.js-avatarLoading').addClass('fadeOut');
+        },
         onImageError: function(errorObject, errorCode, errorMessage){
           console.log(errorObject);
           console.log(errorCode);
@@ -171,6 +166,7 @@ module.exports = Backbone.View.extend({
       self.moderatorFeeHolder = self.$('.js-settingsModeratorFee');
       if(self.model.get('page').profile.avatar_hash){
         $('#settings-image-cropper').cropit('imageSrc', self.serverUrl +'get_image?hash='+self.model.get('page').profile.avatar_hash);
+        self.newAvatar = false;
       }
       //set existing avatar, if any
       $('#settings-image-cropperBanner').cropit({
@@ -181,15 +177,12 @@ module.exports = Backbone.View.extend({
         maxZoom: 5,
         onFileReaderError: function(data){console.log(data);},
         onImageLoading: function(){
+          self.newBanner = true;
           self.$el.find('.js-bannerLoading').removeClass('fadeOut');
-
-          if (self.bannerNeverLoaded) {
-            self.bannerNeverLoaded = false;
-          } else {
-            self.newBanner = true;
-          }          
         },
-        onImageLoaded: function(){self.$el.find('.js-bannerLoading').addClass('fadeOut');},
+        onImageLoaded: function(){
+          self.$el.find('.js-bannerLoading').addClass('fadeOut');
+        },
         onImageError: function(errorObject, errorCode, errorMessage){
           console.log(errorObject);
           console.log(errorCode);
@@ -198,15 +191,16 @@ module.exports = Backbone.View.extend({
       });
       if(self.model.get('page').profile.header_hash){
         $('#settings-image-cropperBanner').cropit('imageSrc', self.serverUrl +'get_image?hash='+self.model.get('page').profile.header_hash);
+        self.newBanner = false;
       }
 
       var editor = new MediumEditor('#about', {
-          placeholder: {
-            text: ''
-          },
-          toolbar: {
-            imageDragging: false
-          }
+        placeholder: {
+          text: ''
+        },
+        toolbar: {
+          imageDragging: false
+        }
       });
     });
     return this;
@@ -218,7 +212,7 @@ module.exports = Backbone.View.extend({
     if (models && models.length) {
       __.each(models, function(model) {
         model.urlRoot = self.serverUrl + 'profile';
-        
+
         // Monkey patching parse so the profile is not nested
         // and therefore change events will be in play.
         model.oldParse = model.parse;
@@ -227,7 +221,7 @@ module.exports = Backbone.View.extend({
             return model.oldParse(response).profile;
           } else {
             return response;
-          }          
+          }
         };
 
         model.fetch({ data: { guid: model.get('guid')} });
@@ -248,8 +242,8 @@ module.exports = Backbone.View.extend({
     if (options.useCached) {
       if (!this.$lazyLoadTrigger.length) {
         throw new Error('Some expected state is missing. renderBlocked() can only'
-          + ' be called with the useCached option after it has been called at least once'
-          + ' without the useCached option.');
+            + ' be called with the useCached option after it has been called at least once'
+            + ' without the useCached option.');
       }
 
       $blockedContainer.html(this.blockedUsersVw.el);
@@ -263,8 +257,8 @@ module.exports = Backbone.View.extend({
 
     function getBlockedGuids() {
       return self.userModel.get('blocked_guids').map(function(guid) {
-          return { guid: guid }
-        });
+        return { guid: guid }
+      });
     }
 
     blockedUsersCl = new usersCl(getBlockedGuids().slice(0, modelsPerBatch));
@@ -277,7 +271,7 @@ module.exports = Backbone.View.extend({
     });
 
     this.$('#blockedForm').html(
-      this.blockedUsersVw.render().el
+        this.blockedUsersVw.render().el
     );
 
     this.$lazyLoadTrigger = $('<div id="blocked_user_lazy_load_trigger">').css({
@@ -303,9 +297,9 @@ module.exports = Backbone.View.extend({
     this.blockedUsersUnblockHandler && this.stopListening(window.obEventBus, null, this.blockedUsersUnblockHandler);
     this.listenTo(window.obEventBus, 'unblockingUser', this.blockedUsersUnblockHandler = function(e) {
       blockedUsersCl.remove(
-        blockedUsersCl.findWhere({ guid: e.guid })
+          blockedUsersCl.findWhere({ guid: e.guid })
       );
-    });    
+    });
 
     // implement scroll based lazy loading of blocked users
     this.$obContainer = this.$obContainer || $('#obContainer');
@@ -314,18 +308,18 @@ module.exports = Backbone.View.extend({
       var colLen;
 
       if (
-        self.getState() === 'blocked' &&
-        blockedUsersCl.length < getBlockedGuids().length &&
-        domUtils.isScrolledIntoView(self.$lazyLoadTrigger[0], self.$obContainer[0])
+          self.getState() === 'blocked' &&
+          blockedUsersCl.length < getBlockedGuids().length &&
+          domUtils.isScrolledIntoView(self.$lazyLoadTrigger[0], self.$obContainer[0])
       ) {
         colLen = blockedUsersCl.length;
 
         blockedUsersCl.add(
-          getBlockedGuids().slice(colLen, colLen + modelsPerBatch)
+            getBlockedGuids().slice(colLen, colLen + modelsPerBatch)
         );
 
         self.patchAndFetchBlockedUsers(
-          blockedUsersCl.slice(colLen, colLen + modelsPerBatch)
+            blockedUsersCl.slice(colLen, colLen + modelsPerBatch)
         )
       }
     }, 200);
@@ -402,9 +396,9 @@ module.exports = Backbone.View.extend({
     });
 
     __.each(languageList, function(l, i){
-        var language_option = $('<option value="'+l.langCode+'">'+l.langName+'</option>');
-        language_option.attr("selected",user.language == l.langCode);
-        language_str += language_option[0].outerHTML;
+      var language_option = $('<option value="'+l.langCode+'">'+l.langName+'</option>');
+      language_option.attr("selected",user.language == l.langCode);
+      language_str += language_option[0].outerHTML;
     });
 
     ship_country.html(ship_country_str);
@@ -653,13 +647,13 @@ module.exports = Backbone.View.extend({
       img64Data.image = imageURI;
 
       saveToAPI('', '', self.serverUrl + "upload_image", function (data) {
-            "use strict";
-            var img_hash = data.image_hashes[0];
-            if(img_hash !== "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb" && img_hash.length == 40){
-              pageData.avatar = img_hash;
-              checkBanner();
-            }
-          },"", img64Data);
+        "use strict";
+        var img_hash = data.image_hashes[0];
+        if(img_hash !== "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb" && img_hash.length == 40){
+          pageData.avatar = img_hash;
+          checkBanner();
+        }
+      },"", img64Data);
     } else {
       checkBanner();
     }
@@ -813,7 +807,7 @@ module.exports = Backbone.View.extend({
     }).render().open();
 
     this.serverConnectSyncHandler &&
-      this.stopListening(app.serverConfig, null, this.serverConnectSyncHandler);
+    this.stopListening(app.serverConfig, null, this.serverConnectSyncHandler);
 
     this.serverConnectSyncHandler = function() {
       // todo: bit of a hack to hide the close button. really, the
@@ -831,7 +825,7 @@ module.exports = Backbone.View.extend({
     serverConnectModal.on('close', function() {
       serverConnectModal.remove();
       this.stopListening(app.serverConfig, null, this.serverConnectSyncHandler);
-    });    
+    });
   },
 
   shutdownServer: function(){
@@ -863,8 +857,8 @@ module.exports = Backbone.View.extend({
     }
 
     this.serverConnectSyncHandler &&
-      app.serverConfig.off(null, this.serverConnectSyncHandler);    
-    
+    app.serverConfig.off(null, this.serverConnectSyncHandler);
+
     this.model.off();
     this.off();
     this.remove();

--- a/js/views/transactionModalVw.js
+++ b/js/views/transactionModalVw.js
@@ -123,7 +123,6 @@ module.exports = baseVw.extend({
 
   render: function () {
     var self = this;
-    console.log(this.model.attributes);
     $('.js-loadingModal').addClass("hide");
     this.model.set('status', this.status);
 
@@ -147,18 +146,31 @@ module.exports = baseVw.extend({
 
   handleSocketMessage: function(response) {
     var data = JSON.parse(response.data);
-    if(data.notification && data.notification.order_id == this.orderID && data.notification.type == "payment received" && this.status == 0){
-      this.status = 1;
+    if(data.notification && data.notification.order_id == this.orderID){
+      switch(data.notification.type){
+        case "payment received":
+          this.status = 1;
+          this.tabState = "summary";
+          break;
+        case "order confirmation":
+          this.status = 2;
+          this.tabState = "summary";
+          break;
+        case "payment recieved":
+          this.status = 3;
+          this.tabState = "summary";
+          break;
+      }
       this.getData();
     } else if(data.message && data.message.subject == this.orderID){
       var messageModel = new Backbone.Model(data.message);
       this.discussionCol.add(messageModel);
-      if(data.message.message_type = "DISPUTE_OPEN"){
+      if(data.message.message_type == "DISPUTE_OPEN"){
         this.status = 4;
         this.tabState = "discussion";
         this.getData();
       }
-      if(data.message.message_type = "DISPUTE_CLOSE"){
+      if(data.message.message_type == "DISPUTE_CLOSE"){
         this.status = 5;
         this.tabState = "discussion";
         this.getData();
@@ -334,7 +346,7 @@ module.exports = baseVw.extend({
     this.discussionCount++;
     this.$('.js-discussionCount').text(this.discussionCount);
     this.discussionScroller[0].scrollTop = this.discussionScroller[0].scrollHeight;
-    this.$('.js-discussionForm').removeClass('disabled');
+    //this.$('.js-discussionForm').removeClass('disabled');
   },
 
   addAllDiscussionMessages: function(){


### PR DESCRIPTION
- when a transaction modal is open, and the status changes, the modal now updates to the summary tab with the new status
- this fixes the issue with mods not seeing dispute chats. It was caused by a modal being set to a status other than 4 and not updating when a dispute is opened, which will cause the messages sent from that modal to not be sent to the moderator.
- this also fixes the problem with avatars not updating from settings by fixing some screwy logic intended to avoid re-uploading old avatars
- this may fix the onboarding avatar upload bug.
- adds the reason for rejection to the purchase rejected error message
