### PR TITLE
fix overflow in item edit description

### DIFF
--- a/js/templates/itemEdit.html
+++ b/js/templates/itemEdit.html
@@ -158,7 +158,10 @@
               </div>
             </div>
             <div class="flexCol-9">
-              <textarea name="description" rows="8" class="fieldItem-textarea custCol-text height130" id="inputDescription" required placeholder="<%= polyglot.t('DescriptionPlaceholder') %>"><%- ob.vendor_offer.listing.item.description %></textarea>
+              <textarea name="description" rows="8" class="fieldItem-textarea custCol-text height130 overflowHidden"
+                        id="inputDescription" required placeholder="<%= polyglot.t('DescriptionPlaceholder') %>">
+                <%- ob.vendor_offer.listing.item.description %>
+              </textarea>
             </div>
           </div>
         </div>

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -78,13 +78,14 @@ module.exports = baseVw.extend({
 
       setTimeout(() => {
         var editor = new MediumEditor('#inputDescription', {
-            placeholder: {
-              text: ''
-            },
-            toolbar: {
-              imageDragging: false,
-              sticky: true
-            }
+          placeholder: {
+            text: window.polyglot.t('DescriptionPlaceholder')
+          },
+          toolbar: {
+            imageDragging: false,
+            sticky: true
+          },
+          disableExtraSpaces: true
         });
 
         editor.subscribe('blur', self.validateDescription);


### PR DESCRIPTION
Hides overflow on itemEdit description field, fixes the placeholder text not appearing. 
closes #830
