### PR TITLE
fix moderator modal

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -125,6 +125,13 @@ window.addEventListener("drop",function(e){
   e.preventDefault();
 },false);
 
+//prevent enter from submitting forms
+window.addEventListener('keypress', function(event) {
+  if (event.keyCode == 13) {
+    event.preventDefault();
+  }
+});
+
 var setCurrentBitCoin = function(cCode, userModel, callback) {
   "use strict";
   getBTPrice(cCode, function (btAve, currencyList) {

--- a/js/templates/moderatorSettings.html
+++ b/js/templates/moderatorSettings.html
@@ -46,7 +46,7 @@
                   <div class="flexRow js-moderatorSettingsFeeHolder">
                     <div class="flexCol-5 custCol-border">
                       <div class="fieldItem">
-                        <label for="moderatorSettingsFeeInput"><%= polyglot.t('moderatorSettings.ServiceFee') %></label>
+                        <label for="moderatorSettingsModalFeeInput"><%= polyglot.t('moderatorSettings.ServiceFee') %></label>
                         <div class="textOpacity50 fontSize12"><%= polyglot.t('moderatorSettings.ServiceFeeNote') %></div>
                       </div>
                     </div>
@@ -58,8 +58,9 @@
                              name="moderation_fee"
                              maxlength="2"
                              class="fieldItem custCol-text width70px floatLeft alignRight"
-                             id="moderatorSettingsFeeInput"
-                             value="<%= ob.page.profile.moderation_fee.toFixed(2) %>" required/><label class="paddingLeft2 floatLeft fieldItem textOpacity75">%</label>
+                             id="moderatorSettingsModalFeeInput"
+                             value="<%= Number(ob.page.profile.moderation_fee).toFixed(2) %>" required/>
+                      <label class="paddingLeft2 floatLeft fieldItem textOpacity75">%</label>
                     </div>
                   </div>
                 </form>

--- a/js/views/moderatorSettingsVw.js
+++ b/js/views/moderatorSettingsVw.js
@@ -16,7 +16,7 @@ module.exports = Backbone.View.extend({
     'click .js-moderatorSettingsSave': 'saveModeratorSettings',
     'click #moderatorSettingsModYes': 'showModeratorFeeHolder',
     'click #moderatorSettingsModNo': 'hideModeratorFeeHolder',
-    'keyup #moderatorSettingsFeeInput': 'keypressFeeInput',
+    'keyup #moderatorSettingsModalFeeInput': 'keypressFeeInput',
     'blur input': 'validateInput'
   },
 
@@ -41,18 +41,18 @@ module.exports = Backbone.View.extend({
 
       //append the view to the passed in parent
       self.parentEl.append(self.$el);
-      self.moderatorFeeInput = self.$('#moderatorSettingsFeeInput');
+      self.moderatorFeeInput = self.$('#moderatorSettingsModalFeeInput');
     });
     return this;
   },
 
  keypressFeeInput: function(){
     "use strict";
-    var fee = $('#moderatorSettingsFeeInput').val();
+    var fee = this.moderatorFeeInput.val();
 
     if (fee.indexOf('.') > 0 && fee.split('.')[1].length > 2) {
       fee = fee.substr(0, fee.length-1);
-      $('#moderatorSettingsFeeInput').val(fee);
+      this.moderatorFeeInput.val(fee);
     }
  },
 
@@ -67,10 +67,12 @@ module.exports = Backbone.View.extend({
 
     moderatorData.name = self.model.get('page').profile.name;
     moderatorData.location = self.model.get('page').profile.location;
+    this.model.set('moderation_fee', moderatorFee);
+    this.model.set('moderator', this.moderatorStatus);
 
     saveToAPI(targetForm, '', self.model.get('user').serverUrl + "profile", function(){
-      self.closeModeratorSettings();
       window.obEventBus.trigger("moderatorStatus", {'status': self.moderatorStatus, 'fee': moderatorFee});
+      self.closeModeratorSettings();
     }, "", moderatorData);
 
     $.ajax({
@@ -114,12 +116,11 @@ module.exports = Backbone.View.extend({
 
   closeModeratorSettings: function() {
     "use strict";
-    this.close();
     $('#obContainer').removeClass('overflowHidden').removeClass('blur');
+    this.close();
   },
 
   close: function(){
-    this.unbind();
     this.remove();
   }
 

--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -9,7 +9,7 @@ var __ = require('underscore'),
     NotificationsCl = require('../collections/notificationsCl.js'), 
     languagesModel = require('../models/languagesMd'),
     baseVw = require('./baseVw'),
-    adminPanelView = require('../views/adminPanelVw'),
+    //adminPanelView = require('../views/adminPanelVw'),
     NotificationsVw = require('../views/notificationsVw'),
     remote = require('remote'),
     messageModal = require('../utils/messageModal.js');
@@ -212,9 +212,11 @@ module.exports = baseVw.extend({
           .html(self.notificationsVw.render().el);
 
       //add the admin panel
+      /*
       self.adminPanel && self.adminPanel.remove();
       self.adminPanel = new adminPanelView({model: self.model});
       self.registerChild(self.adminPanel);
+      */
 
       self.addressInput = self.$el.find('.js-navAddressBar');
       self.statusBar = self.$el.find('.js-navStatusBar');

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -1396,13 +1396,10 @@ module.exports = baseVw.extend({
   },
 
   showModeratorModal: function(){
-    "use strict";
-    var self = this,
-        moderatorSettingsModel = new Backbone.Model();
-    moderatorSettingsModel.set(this.model.attributes);
-    this.moderatorSettingsView = new moderatorSettingsVw({model:moderatorSettingsModel, parentEl: '#modalHolder'});
+    var self = this;
+
+    this.moderatorSettingsView = new moderatorSettingsVw({model:this.model, parentEl: '#modalHolder'});
     this.subViews.push(this.moderatorSettingsView);
-    this.subModels.push(moderatorSettingsModel);
   },
 
   changeModeratorStatus: function(status, fee){


### PR DESCRIPTION
- enter key no longer triggers a form submit on any form, which prevents
  the page from refreshing
- after setting moderator fee in the modal, the fee is cast as a Number
  in the template to prevent an error when it is a string
- the model of the user view is updated when the moderator settings
  modal values are saved without a trip to the server
  Closes #626 
