### PR TITLE
don't submit unused page settings fields

### DIFF
--- a/js/templates/settings.html
+++ b/js/templates/settings.html
@@ -627,7 +627,7 @@
               </div>
 
               <div class="flexCol-9 borderRight0 custCol-border">
-                <input name="primaryColor"
+                <input name="primary_color"
                        type="text"
                        id="primaryColor"
                        class="fieldItem"
@@ -644,7 +644,7 @@
               </div>
 
               <div class="flexCol-9 borderRight0 custCol-border">
-                <input name="secondaryColor"
+                <input name="secondary_color"
                        type="text"
                        id="secondaryColor"
                        class="fieldItem"
@@ -662,7 +662,7 @@
               </div>
 
               <div class="flexCol-9 borderRight0 custCol-border">
-                <input name="backgroundColor"
+                <input name="background_color"
                        type="text"
                        id="backgroundColor"
                        class="fieldItem"
@@ -679,7 +679,7 @@
               </div>
 
               <div class="flexCol-9 borderRight0 custCol-border">
-                <input name="textColor"
+                <input name="text_color"
                        type="text"
                        id="textColor"
                        class="fieldItem"

--- a/js/utils/saveToAPI.js
+++ b/js/utils/saveToAPI.js
@@ -40,6 +40,13 @@ module.exports = function(form, modelJSON, endPoint, onSucceed, onFail, addData,
       }
     });
 
+    //temporarily disable any form fields overriden by manual data so they aren't double submitted
+    __.each(addData, function(value, key) {
+      var disInp = form.find('input[name="'+key+'"]');
+      disInp.attr('disabled', true);
+      tempDisabledFields.push(disInp.attr('id'));
+    });
+
     __.each(form.serializeArray(), function (value) {
       formKeys.push(value.name);
     });


### PR DESCRIPTION
- color fields on the page settings tabs had unused names to avoid
  double submitting to the server, as the colors had to be processed
  before being sent
- this switches the names back to the names used by the API, and changes
  SaveToAPI so that any field being manually added is disabled in the
  form. This allows manipulation of data from the form without having to
  jump through hoops to prevent double submissions.
