### PR TITLE
restoring address bar text on bad handle + removing code that strips …

### DIFF
--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -223,7 +223,10 @@ module.exports = baseVw.extend({
       //listen for address bar set events
       self.listenTo(window.obEventBus, "setAddressBar", function(options){
         var text = options.handle || options.addressText;
-        self.addressInput.val(text ? "ob://" + text: "");
+        
+        text = text ? 'ob://' + text : '';
+        self._lastSetAddressBarText = text;
+        self.addressInput.val(text);
         self.closeStatusBar();
       });
       if(self.showDiscIntro){
@@ -438,7 +441,6 @@ module.exports = baseVw.extend({
     if (e.keyCode == 13){
       if (barText.startsWith('ob://')) {
         sliced = barText.length > 5 ? barText.slice(5) : '';
-        this.addressInput.val(sliced);        
         sliced && this.addressBarProcess(sliced);
       } else {
         this.addressBarProcess(barText);  
@@ -454,6 +456,10 @@ module.exports = baseVw.extend({
     // if new address text comes before another has been processed.
     app.router.translateRoute(addressBarText).done((route) => {
       Backbone.history.navigate(route, {trigger:true});
+    }).fail((reason) => {
+      if (reason === 'bad-handle') {
+        this.addressInput.val(this._lastSetAddressBarText || '');
+      }
     });
   },
 


### PR DESCRIPTION
…out ob://

Minor address bar tweaks:
- on bad handle, restores the previous address bar text.
- removes code which was stripping out 'ob://' from the address bar text. That had been put in before I knew that we want that text in the address bar.
