### PR TITLE
Signature handling

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -5226,6 +5226,12 @@ input[type="checkbox"].fieldItem:checked + label .togLabelOff {
   pointer-events: none;
 }
 
+#ov1 .foldIn {
+  height: 0;
+  overflow: hidden;
+  transition: height 1s;
+}
+
 #ov1 .underline {
   text-decoration: underline;
 }

--- a/js/models/languagesMd.js
+++ b/js/models/languagesMd.js
@@ -105,6 +105,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key",
         Signature: "PGP Signature",
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key",
         Snapchat: "Snapchat",
         BUYNOW: "Buy Now",
         Description: "Description",
@@ -654,6 +655,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key",  //not translated
         Signature: "PGP Signature",  //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "COMPRAR AHORA",
         Description: "Descripci&oacute;n",
@@ -1147,6 +1149,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "JETZT KAUFEN",
         Description: "Beschreibung",
@@ -1681,6 +1684,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key",
         Signature: "Firma PGP",
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "COMPRA ORA",
         Description: "Descrizione",
@@ -2237,6 +2241,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "Clé PGP",
         Signature: "Signature PGP",
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "Acheter Maintenant",
         Description: "Description",
@@ -2769,6 +2774,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "CUMPĂRAȚI ACUM",
         Description: "Descriere",
@@ -3300,6 +3306,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "Купи сейчас",
         Description: "Описание",
@@ -3830,6 +3837,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "KÚPIŤ IHNEĎ",
         Description: "Popis",
@@ -4366,6 +4374,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "Hemen Al",
         Description: "Tanım",
@@ -4900,6 +4909,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Mach mu'",
         PGPKey: "PGP Key",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "MIllogh naked nuvpu'",
         BUYNOW: "DaH je'",
         Description: "Bang",
@@ -5434,6 +5444,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP Key", //not translated
         Signature: "PGP签名",
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "立即购买",
         Description: "描述",
@@ -5974,6 +5985,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "트위터",
         PGPKey: "PGP Key",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "스냅채트",
         BUYNOW: "지금 구매",
         Description: "설명",
@@ -6504,6 +6516,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGPキー",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "今すぐ購入する",
         Description: "商品の説明",
@@ -7029,6 +7042,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "Klucz PGP",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "Kup teraz",
         Description: "Opis",
@@ -7538,6 +7552,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "PGP-nøgle",
         Signature: "PGP Signature", //not translated
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "Køb nu",
         Description: "Beskrivelse",
@@ -8075,6 +8090,7 @@ module.exports = Backbone.Model.extend({
         Twitter: "Twitter",
         PGPKey: "Chave PGP",
         Signature: "Assinatura PGP",
+        SignaturePlaceholder: "A PGP Signature is required if you enter a PGP Key", //not translated
         Snapchat: "Snapchat",
         BUYNOW: "Comprar agora",
         Description: "Descrição",

--- a/js/models/userMd.js
+++ b/js/models/userMd.js
@@ -38,7 +38,7 @@ module.exports = Backbone.Model.extend({
     terms_conditions: "No terms or conditions", //default terms/conditions (string)
     refund_policy: "No refund policy", //default refund policy (string)
 
-    //bitcoinValidationRegex: "^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$"
+    //bitcoinValidationRegex: "^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$",
     //remove this when in production, this is for testNet addresses
     bitcoinValidationRegex: "^[2mn][a-km-zA-HJ-NP-Z1-9]{25,34}$",
     moderators: [],

--- a/js/templates/settings.html
+++ b/js/templates/settings.html
@@ -440,7 +440,7 @@
               </div>
             </div>
 
-            <div class="flexRow js-settingsSignatureRow" style="overflow: hidden; height: 0; transition: height 1s;">
+            <div class="flexRow foldIn js-settingsSignatureRow">
               <div class="flexCol-3 borderRight custCol-border">
                 <div class="fieldItem">
                   <label for="signature"><%= polyglot.t('Signature') %></label>
@@ -451,7 +451,7 @@
                 <input name="signature"
                        type="text"
                        id="signature"
-                       placeholder="<%= polyglot.t('Signature') %>"
+                       placeholder="<%= polyglot.t('SignaturePlaceholder') %>"
                        class="fieldItem">
               </div>
             </div>

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -56,7 +56,7 @@ module.exports = Backbone.View.extend({
     'click #advancedForm input[name="notFancy"]': 'toggleFancyStyles',
     'blur input': 'validateInput',
     'blur textarea': 'validateInput',
-    'input #pgp_key': 'showSignature'
+    'input #pgp_key': 'checkPGPKey'
   },
 
   initialize: function(options){
@@ -850,9 +850,14 @@ module.exports = Backbone.View.extend({
     });
   },
 
-  showSignature: function(){
-    var targ = this.$('.js-settingsSignatureRow');
-    targ.css("height", 50);
+  checkPGPKey: function(e){
+    if(!this.$(e.target).val().length){
+      this.$('.js-settingsSignatureRow').css("height", 0);
+      this.$('#signature').removeAttr("required");
+    } else {
+      this.$('.js-settingsSignatureRow').css("height", 50);
+      this.$('#signature').attr("required", '');
+    }
   },
 
   toggleFancyStyles: function(){


### PR DESCRIPTION
- gives an error if a user tries to save a pgp key without a signature
- labels the signature field more clearly
- hides the signature field if the pgp key field text is deleted

Closes #907 
