### PR TITLE
restoring fullscreen option

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -1735,6 +1735,10 @@ margin: auto;
   transition: initial;
 }
 
+.fullscreen .btn.btn-win {
+  display: none;
+}
+
 .btn.btn-win.btn-winClose {
   background-color: #E45A5A;
   position: relative;

--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,7 @@ window.onblur = function() {
 };
 
 var Polyglot = require('node-polyglot'),
+    ipcRenderer = require('ipc-renderer'),
     getBTPrice = require('./utils/getBitcoinPrice'),
     router = require('./router'),
     userModel = require('./models/userMd'),
@@ -139,6 +140,15 @@ window.addEventListener('keypress', function(event) {
   if (event.keyCode == 13) {
     event.preventDefault();
   }
+});
+
+//manage app being or not in fullscreen mode
+ipcRenderer.on('fullscreen-enter', (e) => {
+  $('body').addClass('fullscreen');
+});
+
+ipcRenderer.on('fullscreen-exit', (e) => {
+  $('body').removeClass('fullscreen');
 });
 
 var setCurrentBitCoin = function(cCode, userModel, callback) {

--- a/main.js
+++ b/main.js
@@ -224,6 +224,30 @@ app.on('ready', function() {
             }
           }
         },
+        {
+          label: 'Toggle Full Screen',
+          accelerator: (function() {
+            if (platform == 'mac') {
+              return 'Ctrl+Command+F';
+            } else {
+              return 'Ctrl+Shift+F';
+            }
+          })(),
+          click: function(item, focusedWindow) {
+            var fullScreen;
+
+            if (mainWindow) {
+              fullScreen = !mainWindow.isFullScreen();
+              mainWindow.setFullScreen(fullScreen);
+
+              if (fullScreen) {
+                mainWindow.webContents.send('fullscreen-enter');
+              } else {
+                mainWindow.webContents.send('fullscreen-exit');
+              }
+            }
+          }
+        },        
       ]
     },
     {


### PR DESCRIPTION
https://github.com/OpenBazaar/OpenBazaar-Client/issues/367

I've observed how a couple of standard apps (e.g. Chrome) behave in fullscreen mode. At least on OSX, when an app enters fullscreen mode, it's close, minimize & maximize options are not visible. I replicated that behavior for our app and it makes the referenced bug moot.

So, to close an app from fullscreen mode, you either exit fullscreen mode first and click the 'x' in the menu bar -or- you can use the keyboard shortcut for quit and quit directly from fullscreen mode.
