### PR TITLE
Ignore cert errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -167,6 +167,8 @@ app.on('before-quit', function (e) {
     }
 });
 
+app.commandLine.appendSwitch('ignore-certificate-errors', true);
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 app.on('ready', function() {


### PR DESCRIPTION
Adds a setting to ignore certificate errors, this should prevent Chromium from disabling caching on remote servers with self-signed certs.
