### PR TITLE
Handle HTML in Fields More Robustly

### DIFF
--- a/js/models/itemMd.js
+++ b/js/models/itemMd.js
@@ -186,6 +186,9 @@ module.exports = window.Backbone.Model.extend({
 
       });
 
+      //unescape any html
+      response.vendor_offer.listing.item.description = __.unescape(response.vendor_offer.listing.item.description);
+
       //change any plain text urls in the description into links
       response.vendor_offer.listing.item.displayDescription = autolinker.link(response.vendor_offer.listing.item.description, {'twitter': false, 'hashtag': false});
 

--- a/js/models/itemShortMd.js
+++ b/js/models/itemShortMd.js
@@ -1,4 +1,5 @@
-var Backbone = require('backbone'),
+var __ = require('underscore'),
+    Backbone = require('backbone'),
     getBTPrice = require('../utils/getBitcoinPrice');
 
 module.exports = Backbone.Model.extend({
@@ -19,12 +20,17 @@ module.exports = Backbone.Model.extend({
     handle: 0,
     avatar_hash: "",
     priceSet: 0, //set in Update Attribute below, so view can listen for it
-    short_description: "",
+    short_description: ""
   },
 
   initialize: function(){
     this.updateAttributes();
     //this.on('change', this.updateAttributes, this);
+  },
+
+  parse: function(response){
+    response.short_description = __.unescape(response.short_description);
+    return response;
   },
 
   updateAttributes: function(){

--- a/js/models/userProfileMd.js
+++ b/js/models/userProfileMd.js
@@ -106,6 +106,9 @@ module.exports = Backbone.Model.extend({
         response.avatar_hash = response.profile.avatar_hash;
       }
 
+      //unescape the text
+      response.profile.about = __.unescape(response.profile.about);
+
       //change any plain text urls in the about field into links
       response.profile.displayAbout = autolinker.link(response.profile.about, {'twitter': false, 'hashtag': false});
 

--- a/js/models/userShortMd.js
+++ b/js/models/userShortMd.js
@@ -1,4 +1,5 @@
-var Backbone = require('backbone');
+var __ = require('underscore'),
+    Backbone = require('backbone');
 
 var ShortItemModel = module.exports = Backbone.Model.extend({
   defaults: {
@@ -8,5 +9,10 @@ var ShortItemModel = module.exports = Backbone.Model.extend({
     avatar_hash: "",
     nsfw: false,
     short_description: ""
+  },
+
+  parse: function(response){
+    response.short_description = __.unescape(response.short_description);
+    return response;
   }
 });

--- a/js/templates/item.html
+++ b/js/templates/item.html
@@ -137,7 +137,7 @@
       <div class="flexContainer flex-border custCol-primary js-description js-tabTarg textOpacity75 minHeight300 <% ob.activeTab !== 'description' && print('hide') %>">
         <div class="flexRow">
           <div class="rowItem fontSize16 padding30 paddingTop10 lineHeight24 fontWeight400">
-            <p class="js-listingDescription"></p>
+            <%= ob.vendor_offer.listing.item.displayDescription %>
           </div>
         </div>
       </div>

--- a/js/templates/settings.html
+++ b/js/templates/settings.html
@@ -480,7 +480,7 @@
                     name="about"
                     id="about"
                     rows="10"
-                    class="fieldItem-textarea height130"
+                    class="fieldItem-textarea height130 overflowHidden"
                     placeholder="<%= polyglot.t('AboutPlaceholder') %>"><%= ob.page.profile.about %></textarea>
               </div>
             </div>

--- a/js/utils/validateMediumEditor.js
+++ b/js/utils/validateMediumEditor.js
@@ -1,8 +1,19 @@
+var sanitizeHTML = require('sanitize-html');
+
 function checkVal($field) {
-  var fVal = $($field.val()).text().trim();
+  var fVal = $field.val().trim();
   if (!fVal.length || fVal == "<p>&nbsp;</p>" || fVal == "&nbsp;") {
     $field.val('');
   }
+
+  //replace double quotes with single quotes to avoid invalid json
+  fVal = fVal.replace(/\\([\s\S])|(")/g, "'");
+
+  fVal = sanitizeHTML(fVal, {
+    allowedTags: [ 'h2','h3', 'h4', 'h5', 'h6', 'p', 'a','u','ul', 'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'hr', 'br', 'img', 'blockquote' ]
+  });
+  
+  $field.val(fVal);
 
   if (!$field[0].checkValidity()) {
     $field.parent().addClass('invalid');

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -92,8 +92,17 @@ module.exports = baseVw.extend({
             sticky: true
           },
           paste: {
-            forcePlainText: false,
-            cleanPastedHTML: false
+            cleanPastedHTML: true,
+            cleanReplacements: [
+              [new RegExp(/<div>/gi), '<p>'],
+              [new RegExp(/<\/div>/gi), '</p>'],
+              [new RegExp(/<font>/gi), ""],
+              [new RegExp(/<\/font>/gi), ""],
+              [new RegExp(/<code>/gi), '<pre>'],
+              [new RegExp(/<\/code>/gi), '</pre>']
+            ],
+            cleanAttrs: ['class', 'style', 'dir', 'color', 'face', 'size', 'align', 'border', 'background', 'opacity'],
+            cleanTags: ['meta', 'style', 'script', 'center', 'basefont', 'frame', 'iframe', 'frameset' ]
           }
         });
 

--- a/js/views/itemVw.js
+++ b/js/views/itemVw.js
@@ -101,12 +101,6 @@ module.exports = baseVw.extend({
           )
         );
 
-        var description = sanitizeHTML(self.model.get('vendor_offer').listing.item.displayDescription, {
-          allowedTags: [ 'h2','h3', 'h4', 'h5', 'h6', 'p', 'a','u','ul', 'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'hr', 'br', 'img', 'blockquote' ]
-        });
-
-        self.$('.js-listingDescription').html(description);
-
         if (!self.reviewsVw) {
           self.reviewsVw = new ReviewsVw({ collection: self.ratingCl });
           self.registerChild(self.reviewsVw);

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -205,8 +205,17 @@ module.exports = Backbone.View.extend({
           imageDragging: false
         },
         paste: {
-          forcePlainText: false,
-          cleanPastedHTML: false
+          cleanPastedHTML: true,
+          cleanReplacements: [
+            [new RegExp(/<div>/gi), '<p>'],
+            [new RegExp(/<\/div>/gi), '</p>'],
+            [new RegExp(/<font>/gi), ""],
+            [new RegExp(/<\/font>/gi), ""],
+            [new RegExp(/<code>/gi), '<pre>'],
+            [new RegExp(/<\/code>/gi), '</pre>']
+          ],
+          cleanAttrs: ['class', 'style', 'dir', 'color', 'face', 'size', 'align', 'border', 'background', 'opacity'],
+          cleanTags: ['meta', 'style', 'script', 'center', 'basefont', 'frame', 'iframe', 'frameset' ]
         }
       });
       editor.subscribe('blur', self.validateDescription);

--- a/js/views/storeWizardVw.js
+++ b/js/views/storeWizardVw.js
@@ -109,8 +109,17 @@ module.exports = Backbone.View.extend({
           imageDragging: false
         },
         paste: {
-          forcePlainText: false,
-          cleanPastedHTML: false
+          cleanPastedHTML: true,
+          cleanReplacements: [
+            [new RegExp(/<div>/gi), '<p>'],
+            [new RegExp(/<\/div>/gi), '</p>'],
+            [new RegExp(/<font>/gi), ""],
+            [new RegExp(/<\/font>/gi), ""],
+            [new RegExp(/<code>/gi), '<pre>'],
+            [new RegExp(/<\/code>/gi), '</pre>']
+          ],
+          cleanAttrs: ['class', 'style', 'dir', 'color', 'face', 'size', 'align', 'border', 'background', 'opacity'],
+          cleanTags: ['meta', 'style', 'script', 'center', 'basefont', 'frame', 'iframe', 'frameset' ]
         }
       });
       editor.subscribe('blur', self.validateDescription);

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -243,9 +243,7 @@ module.exports = baseVw.extend({
     });    
 
     this.listenTo(window.obEventBus, "itemShortDelete", function(options){
-      this.setItem(options.contract_hash, function(){
-        self.deleteItem();
-      });
+      self.deleteItem(false, options.contract_hash);
     });
 
     this.listenTo(window.obEventBus, "moderatorStatus", function(options){
@@ -1300,9 +1298,10 @@ module.exports = baseVw.extend({
     this.deleteItem(true);
   },
 
-  deleteItem: function(confirm){
+  deleteItem: function(confirm, id){
     "use strict";
-    var self=this;
+    var self=this,
+        deleteID = id || this.item.get('id');
 
     if(this.confirmDelete === false && confirm){
       this.$el.find('.js-deleteItem').addClass('confirm');
@@ -1310,12 +1309,14 @@ module.exports = baseVw.extend({
     } else {
       $.ajax({
         type: "DELETE",
-        url: self.item.get('serverUrl') + "contracts/?id=" + self.item.get('id'),
+        url: self.model.get('user').serverUrl + "contracts/?id=" + deleteID,
         success: function () {
           if (self.isRemoved()) return;
 
           //destroy the model. Do it this way because the server can't accept a standard destroy call, and we don't want to call the server twice.
-          self.item.trigger('destroy', self.item);
+          if(self.item){
+            self.item.trigger('destroy', self.item);
+          }
           self.fetchListings();
           self.setState("store");
         },


### PR DESCRIPTION
- swap " for ' in all medium editor fields
- extra sanitization of medium editor output
- more restrictions on pasted data in the medium editor
- unescape data with html in description fields when it returns from the
  server
- remove redundant sanitization in item view
