### PR TITLE
Tweaks

### DIFF
--- a/js/templates/pageConnectModal.html
+++ b/js/templates/pageConnectModal.html
@@ -5,7 +5,7 @@
   </div>
 
   <div class="content">
-    <div class="statusText pad10 marginBottom12 inlineBlock <% ob.tooltip && print('tooltip') %>" <% ob.tooltip && print(`data-tooltip="${ob.tooltip}"`) %>><%= ob.statusText %></div>
+    <div class="statusText pad10 marginBottom12 inlineBlock custCol-text <% ob.tooltip && print('tooltip') %>" <% ob.tooltip && print(`data-tooltip="${ob.tooltip}"`) %>><%= ob.statusText %></div>
 
     <div>
       <a class="btn btn-large custCol-secondary js-cancel btn-cancel">Cancel</a>

--- a/js/views/pageConnectModal.js
+++ b/js/views/pageConnectModal.js
@@ -39,8 +39,7 @@ module.exports = baseModal.extend({
     }
   },
 
-  onBackClick: function(e) {
-    $(e.target).addClass('disabled');
+  onBackClick: function() {
     this.trigger('back');
   },
 
@@ -48,8 +47,7 @@ module.exports = baseModal.extend({
     this.trigger('retry');
   },
 
-  onCancelClick: function(e) {
-    $(e.target).addClass('disabled');
+  onCancelClick: function() {
     this.trigger('cancel');
   },    
 

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -365,7 +365,7 @@ module.exports = baseVw.extend({
       self.undoCustomAttributes.secondary_color = self.model.get('page').profile.secondary_color;
       self.undoCustomAttributes.text_color = self.model.get('page').profile.text_color;
       self.setCustomStyles();
-      self.setState(self.state, self.currentItemHash);
+      self.setState(self.state, self.currentItemHash, { replaceHistory: true });
 
       //check if user is blocked
       if(!self.options.ownPage && isBlocked) {
@@ -447,12 +447,14 @@ module.exports = baseVw.extend({
     }
   },
 
-  setState: function(state, hash) {
+  setState: function(state, hash, options) {
     "use strict";
     var currentAddress,
         addressState,
         currentHandle = this.model.get('page').profile.handle,
         isItemType = false;
+
+    options = options || {};
 
     if(state === "listing"){
       //clear old templates
@@ -465,19 +467,19 @@ module.exports = baseVw.extend({
     }else if(state === "listingNew"){
       this.tabClick(this.$el.find(".js-storeTab"), this.$el.find(".js-store"));
       $('#obContainer').scrollTop(352);
-      this.addTabToHistory('listingNew');
+      this.addTabToHistory('listingNew', options.replaceHistory);
       this.sellItem();
     } else if(state === "createStore") {
       this.tabClick(this.$el.find(".js-aboutTab"), this.$el.find(".js-about"));
-      this.addTabToHistory('about');
+      this.addTabToHistory('about', options.replaceHistory);
       this.createStore();
     } else if(state === "becomeModerator"){
       this.tabClick(this.$el.find(".js-aboutTab"), this.$el.find(".js-about"));
-      this.addTabToHistory('about');
+      this.addTabToHistory('about', options.replaceHistory);
       this.showModeratorModal();
     } else if(state === "customize"){
       this.tabClick(this.$el.find(".js-aboutTab"), this.$el.find(".js-about"));
-      this.addTabToHistory('about');
+      this.addTabToHistory('about', options.replaceHistory);
       this.customizePage();
     }else if(state == "store"){
       //if this page is not a vendor, don't go to their store
@@ -487,7 +489,7 @@ module.exports = baseVw.extend({
         state="about";
       }
       this.tabClick(this.$el.find(".js-" + state + "Tab"), this.$el.find(".js-" + state));
-      this.addTabToHistory(state);
+      this.addTabToHistory(state, options.replaceHistory);
     }else if(state){
       this.tabClick(this.$el.find(".js-" + state + "Tab"), this.$el.find(".js-" + state));
     }else{
@@ -950,12 +952,10 @@ module.exports = baseVw.extend({
     showContent.removeClass('hide');
   },
 
-  addTabToHistory: function(state){
-    console.log('add madd');
-    
+  addTabToHistory: function(state, replace){
     "use strict";
     //add action to history if not an item
-    Backbone.history.navigate('#userPage/'+this.model.get('page').profile.guid + "/" + state);
+    Backbone.history.navigate('#userPage/'+this.model.get('page').profile.guid + "/" + state, { replace: true });
   },
 
   sellItem: function(){

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -951,6 +951,8 @@ module.exports = baseVw.extend({
   },
 
   addTabToHistory: function(state){
+    console.log('add madd');
+    
     "use strict";
     //add action to history if not an item
     Backbone.history.navigate('#userPage/'+this.model.get('page').profile.guid + "/" + state);


### PR DESCRIPTION
# couple minor tweaks:
- using the theme's text class on the message in the page connect modal. This will avoid white on white in a theme with a white bg.
- on the User Page View, replacing (as opposed to adding to) the history state when the state is initially set in render. This avoid a situation where the user navigates to e.g. `guid` and then the view was adding a history state of `guid/about`, which meant if the user clicked back, they would fall on `guid`, which would result in `guid/about` being added back again. Now, on the initial history update it will replace `guid` with `guid/about`, so back will correctly take the user to the page before they entered `guid`.
