### PR TITLE
changing fullscreen shortcut to f11 on non-mac platforms

### DIFF
--- a/main.js
+++ b/main.js
@@ -237,7 +237,7 @@ app.on('ready', function() {
             if (platform == 'mac') {
               return 'Ctrl+Command+F';
             } else {
-              return 'Ctrl+Shift+F';
+              return 'F11';
             }
           })(),
           click: function(item, focusedWindow) {


### PR DESCRIPTION
On Windows, please ensure that F11 toggles fullscreen mode.
