### PR TITLE
Change status msg

### DIFF
--- a/js/utils/getBitcoinPrice.js
+++ b/js/utils/getBitcoinPrice.js
@@ -173,10 +173,6 @@ module.exports = function (currency, callback) {
 
         showStatus && showStatus.remove();
 
-        setTimeout(() => {
-            showStatus.remove();
-        }, 3000);
-
         typeof callback === 'function' && callback(btAve, currencyKeys);
     };
 

--- a/js/utils/getBitcoinPrice.js
+++ b/js/utils/getBitcoinPrice.js
@@ -173,6 +173,10 @@ module.exports = function (currency, callback) {
 
         showStatus && showStatus.remove();
 
+        setTimeout(() => {
+            showStatus.remove();
+        }, 3000);
+
         typeof callback === 'function' && callback(btAve, currencyKeys);
     };
 

--- a/js/views/statusBarVw.js
+++ b/js/views/statusBarVw.js
@@ -67,6 +67,7 @@ module.exports = baseVw.extend({
   //
   pushMessage: function(msg) {
     var md = new StatusMessageMd(),
+        updateMessage,
         errs;
 
     if (typeof msg === 'string') msg = { msg: msg };
@@ -80,10 +81,23 @@ module.exports = baseVw.extend({
     md.set(msg);
     this.collection.add(md);
 
+    updateMessage = (msg) => {
+      if (!msg) {
+        throw new Error('Please provide a msg.');
+      }
+
+      if (typeof msg === 'string') {
+        md.set('msg', msg);
+      } else {
+        md.set(msg);
+      }
+    };
+
     return {
       remove: () => {
         this.collection.remove(md);
-      }
+      },
+      updateMessage: updateMessage
     }
   },
 

--- a/js/views/statusBarVw.js
+++ b/js/views/statusBarVw.js
@@ -89,6 +89,9 @@ module.exports = baseVw.extend({
       if (typeof msg === 'string') {
         md.set('msg', msg);
       } else {
+        // Duration can't be updated. If you plan on updating the message,
+        // you should probably pass in a duration of `false` when you create
+        // the message and then remove it on your own.
         delete msg.duration;
         md.set(msg);
       }

--- a/js/views/statusBarVw.js
+++ b/js/views/statusBarVw.js
@@ -89,6 +89,7 @@ module.exports = baseVw.extend({
       if (typeof msg === 'string') {
         md.set('msg', msg);
       } else {
+        delete msg.duration;
         md.set(msg);
       }
     };


### PR DESCRIPTION
For Status Bar Messages, updated the API of what pushMessage returns to include an `updateMessage` function which allows you to update an existing status message.

I thought this can maybe be useful for https://github.com/OpenBazaar/OpenBazaar-Client/issues/1053, where instead of showing a 'saving...' message and then a separate 'saved!' message, we could just show one that changes from 'saving...' to 'saved!'.
