### PR TITLE
Fix issue with removing blocked user view

### DIFF
--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -923,7 +923,10 @@ module.exports = Backbone.View.extend({
       }
     });
 
-    this.blockedUsersVw.remove();
+    // We haven't previously viewed the list of blocked users
+    if (typeof this.blockedUsersVw !== 'undefined') {
+      this.blockedUsersVw.remove();
+    }
 
     if (this.blockedUsersScrollHandler && this.$obContainer.length) {
       this.$obContainer.off('scroll', this.blockedUsersScrollHandler);


### PR DESCRIPTION
We tried to remove blockedUsersVw object on Settings close(), even the class hasn't been instantiated before. This would throw an "undefined" error.
