### PR TITLE
Minor cosmetic change

### DIFF
--- a/js/templates/transactionModal.html
+++ b/js/templates/transactionModal.html
@@ -993,7 +993,7 @@
         <div>
           <input type="checkbox" class="fieldItem"
                  id="transactionsCloseDisputeCheckbox" >
-          <label for="transactionsCloseDisputeCheckbox" class="fontSize10 clickable compact">
+          <label for="transactionsCloseDisputeCheckbox" class="fontSize10 clickable compact" style="white-space: nowrap;">
             <%= polyglot.t('transactions.CloseDispute') %>
           </label>
         </div>

--- a/js/templates/transactionModal.html
+++ b/js/templates/transactionModal.html
@@ -993,7 +993,7 @@
         <div>
           <input type="checkbox" class="fieldItem"
                  id="transactionsCloseDisputeCheckbox" >
-          <label for="transactionsCloseDisputeCheckbox" class="fontSize10 clickable compact" style="white-space: nowrap;">
+          <label for="transactionsCloseDisputeCheckbox" class="fontSize10 clickable compact" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
             <%= polyglot.t('transactions.CloseDispute') %>
           </label>
         </div>


### PR DESCRIPTION
The Close Dispute text was wrapping which caused part of the transaction modal to overlap the discussion box.  This blocked the bottom line of chat.  This change prevents that.
