### PR TITLE
Status bar confirm order

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -418,7 +418,11 @@
     "TotalInTransaction": "Transaction:",
     "StartDisputeFlag": "START DISPUTE",
     "CloseDisputeFlag": "END DISPUTE",
-    "PayoutOnlyBuyer": "Closing this dispute will return 100% of the funds to the buyer."
+    "PayoutOnlyBuyer": "Closing this dispute will return 100% of the funds to the buyer.",
+    "UpdatingOrder": "Updating your transaction",
+    "UpdateComplete": "Your transaction update is complete",
+    "UpdateFailed": "Your transaction update did not complete. Open the transaction and try again",
+    "UpdateInvalid": "Your transaction update returned invalid data. Open the transaction and try again"
   },
   "errorMessages": {
     "saveError": "Data could not be saved.",

--- a/js/models/statusMessageMd.js
+++ b/js/models/statusMessageMd.js
@@ -13,7 +13,7 @@ module.exports = window.Backbone.Model.extend({
     attrs = attrs || {};
 
     if (attrs.type && ['msg', 'warning', 'confirmed', 'pending'].indexOf(attrs.type) === -1) {
-      err['type'] = 'Type must be "msg", "warning", "confirmed" or "pending"';
+      err['type'] = `Type must be 'msg', 'warning', 'confirmed', or 'pending'`;
     }
 
     if (attrs.duration && !__.isNumber(attrs.duration)) {

--- a/js/models/statusMessageMd.js
+++ b/js/models/statusMessageMd.js
@@ -12,8 +12,8 @@ module.exports = window.Backbone.Model.extend({
 
     attrs = attrs || {};
 
-    if (attrs.type && ['msg', 'warning', 'confirmed'].indexOf(attrs.type) === -1) {
-      err['type'] = `Type must be 'msg', 'warning' or 'confirmed'`;
+    if (attrs.type && ['msg', 'warning', 'confirmed', 'pending'].indexOf(attrs.type) === -1) {
+      err['type'] = 'Type must be "msg", "warning", "confirmed" or "pending"';
     }
 
     if (attrs.duration && !__.isNumber(attrs.duration)) {

--- a/js/templates/statusMessage.html
+++ b/js/templates/statusMessage.html
@@ -3,6 +3,8 @@
     <span class="icon ion-alert-circled"></span>
   <% } else if (ob.type === 'confirmed') { %>
     <span class="icon ion-android-checkbox"></span>
+  <% } else if (ob.type === 'pending') { %>
+  <span class="icon ion-more"></span>
   <% } %>
   <%= ob.msg %>
 </div>

--- a/js/views/transactionModalVw.js
+++ b/js/views/transactionModalVw.js
@@ -322,29 +322,33 @@ module.exports = baseVw.extend({
     });
 
     saveToAPI(targetForm, '', this.serverUrl + "confirm_order", function(data){
-      confirmStatus && confirmStatus.remove();
-      app.statusBar.pushMessage({
+      confirmStatus.updateMessage({
         type: 'confirmed',
-        msg: '<i>' + window.polyglot.t('transactions.UpdateComplete') + '</i>',
-        duration: 3000
+        msg: '<i>' + window.polyglot.t('transactions.UpdateComplete') + '</i>'
       });
-
+      setTimeout(function(){
+        confirmStatus && confirmStatus.remove();
+      },3000);
       }, function(data){
       //onFail
-      confirmStatus && confirmStatus.remove();
-      app.statusBar.pushMessage({
+      confirmStatus.updateMessage({
         type: 'warning',
         msg: '<i>' + window.polyglot.t('transactions.UpdateFailed') + '</i>',
         duration: 3000
       });
+      setTimeout(function(){
+        confirmStatus && confirmStatus.remove();
+      },3000);
     }, confirmData, '', function(){
       //onInvalid
-      confirmStatus && confirmStatus.remove();
-      app.statusBar.pushMessage({
+      confirmStatus.updateMessage({
         type: 'warning',
         msg: '<i>' + window.polyglot.t('transactions.UpdateInvalid') + '</i>',
         duration: 3000
       });
+      setTimeout(function(){
+        confirmStatus && confirmStatus.remove();
+      },3000);
     }, e);
 
     this.closeModal();


### PR DESCRIPTION
This changes the transaction modal so the modal closes when an order is confirmed by a vendor, and a transaction pending message appears in the status bar. Once the transaction completes (or fails) the message is updated and 3 seconds later it closes. 

Closes #1053
