### PR TITLE
Prevent title from being too long for QR code

### DIFF
--- a/js/views/buyWizardVw.js
+++ b/js/views/buyWizardVw.js
@@ -496,7 +496,7 @@ module.exports = Backbone.View.extend({
     "use strict";
     var totalBTCPrice = 0,
         storeName = encodeURI(this.model.get('page').profile.name),
-        message = encodeURI(this.model.get('vendor_offer').listing.item.title + " "+data.order_id),
+        message = encodeURI(this.model.get('vendor_offer').listing.item.title.substring(1, 20) + " "+data.order_id),
         payHREF = "",
         dataURI;
     this.$el.find('.js-buyWizardSpinner').addClass('hide');

--- a/js/views/transactionModalVw.js
+++ b/js/views/transactionModalVw.js
@@ -205,7 +205,7 @@ module.exports = baseVw.extend({
         payHREF,
         dataURI;
     if(this.model.get('buyer_order')){
-      payHREF = "bitcoin:" + this.model.get('buyer_order').order.payment.address + "?amount=" + this.model.get('buyer_order').order.payment.amount + "&message=" + this.model.get('vendor_offer').listing.item.title;
+      payHREF = "bitcoin:" + this.model.get('buyer_order').order.payment.address + "?amount=" + this.model.get('buyer_order').order.payment.amount + "&message=" + this.model.get('vendor_offer').listing.item.title.substring(1, 20);
       dataURI = qr(payHREF, {type: 10, size: 10, level: 'M'});
       this.$el.find('.js-transactionPayQRCode').attr('src', dataURI);
     } else {


### PR DESCRIPTION
Truncate the title of items to 20 characters when embedding them in the QR code to prevent titles from being too long for the amount of data allowed.
