### PR TITLE
Store avatars for transactions

### DIFF
--- a/js/models/orderMd.js
+++ b/js/models/orderMd.js
@@ -121,6 +121,9 @@ module.exports = window.Backbone.Model.extend({
     response.bitcoinValidationRegex = this.bitcoinValidationRegex;
     response.transactionType = this.transactionType;
 
+    response.vendorAvatarURL = localStorage.getItem('userAvatar-'+response.vendor_offer.listing.id.guid);
+    response.buyerAvatarURL = localStorage.getItem('userAvatar-'+response.buyer_order.order.id.guid);
+
     return response;
   },
 

--- a/js/templates/chatConversation.html
+++ b/js/templates/chatConversation.html
@@ -1,5 +1,7 @@
 <div class="chatConversationHeader">
-    <a class="chatConversationAvatar thumbnail-small marginRight5 floatLeft js-username clickable" style="background-image: <%= ob.cssImageUrl(ob.avatar_hash, ob.guid, 'imgs/defaultUser.png') %>;" href="#userPage/<%= ob.guid %>/store"></a>
+    <a class="chatConversationAvatar thumbnail-small marginRight5 floatLeft js-username clickable"
+       style="background-image: <%= ob.cssImageUrl(ob.avatar_hash, ob.guid, 'imgs/defaultUser.png') %>;"
+       href="#userPage/<%= ob.guid %>/store"></a>
     <div class="chatConversationLabel floatLeft js-username"><%= ob.handle || ob.guid %></div>
     <div class="conversationHeader-btn floatRight marginTop4 textOpacity75">
         <a class="ion-close-round js-closeConversation"></a>

--- a/js/templates/chatHead.html
+++ b/js/templates/chatHead.html
@@ -1,7 +1,7 @@
 <div class="chatHead js-chatHead clickable tooltip <% if(ob.unread === 0) { %>chatRead<% } %>" data-tooltip="<%=ob.guid%>">
     <div id="chatHead_<%=ob.guid%>" class="thumbnail clickable custcol-border chatHeadIcon badge"
-         style="background-image: <% if (ob.avatar_hash) {%>url(<%= ob.serverUrl %>/get_image?hash=<%= ob.avatar_hash %>&guid=<%= ob.guid %>),<% } %> url(imgs/defaultUser.png); height: 36px; width: 36px"
-         <% if(ob.unread > 0) { %>data-count="<%= ob.unread %>"<% } %>></div>
+         style="background-image: <%= ob.cssImageUrl(ob.avatar_hash, ob.guid, 'imgs/defaultUser.png') %>; height: 36px; width: 36px"
+    <% if(ob.unread > 0) { %>data-count="<%= ob.unread %>"<% } %>></div>
     <div class="chatPreview">
         <div class="chatPreviewSender">
             <% if(ob.handle) { %>

--- a/js/templates/transactionModal.html
+++ b/js/templates/transactionModal.html
@@ -549,10 +549,10 @@
               <a href="#userPage/<%- ob.vendor_offer.listing.id.guid %>/item/<%- ob.vendor_offer.listing.contract_id %>">
               <div class="thumbnail thumbnail-large-slim floatLeft marginRight10"
                           <% if(ob.vendor_offer.listing.item.image_hashes){ %>
-      style="background-image: url(<%- ob.serverUrl %>get_image?hash=<%- ob.vendor_offer.listing.item.image_hashes[0] %>&guid=<%-ob.vendor_offer.listing.id.guid %>), url(imgs/defaultBanner.png);"
-      <% } else { %>
-      style="background-image: url(imgs/defaultBanner.png);"
-      <% } %>>
+                          style="background-image: url(<%- ob.serverUrl %>get_image?hash=<%- ob.vendor_offer.listing.item.image_hashes[0] %>&guid=<%-ob.vendor_offer.listing.id.guid %>), url(imgs/defaultBanner.png);"
+                          <% } else { %>
+                          style="background-image: url(imgs/defaultBanner.png);"
+                          <% } %>>
                         </div>
                 </a>
               <div class="txt-unleaded">
@@ -680,13 +680,13 @@
       <% if(ob.buyer_order.order.shipping) { %>
       <div class="flexRow custCol-border borderBottom">
         <div class="flexRow rowItem padding15">
-          <div class="thumbnail-large-slim floatLeft marginRight10">
+          <div class="thumbnail-large-slim pull-left marginRight10">
             <div class="thumbnail thumbnail-large-slim custCol-secondary alignCenter" >
               <span class="ion-cube textOpacity1 fontSize20 positionAbsolute" style="left: 33%; top: 23%;"></span>
               <span class="fontSize10 textOpacity1 positionAbsolute width100 alignCenter left0 bottom8px"><%= polyglot.t('ShipTo') %></span>
             </div>
           </div>
-          <div class="txt-unleaded">
+          <div class="txt-unleaded pull-left">
             <div class="fontSize13 lineHeight16">
               <%- ob.buyer_order.order.shipping.ship_to %>, <br />
               <%- ob.buyer_order.order.shipping.address %><br />
@@ -703,58 +703,56 @@
       <div class="flexRow custCol-border borderBottom">
         <div class="flexRow rowItem padding15">
           <div class="flexCol-8">
-              <a href="#userPage/<%- ob.vendor_offer.listing.id.guid %>/item/<%- ob.vendor_offer.listing.contract_id %>">
-                <div class="thumbnail thumbnail-large-slim floatLeft marginRight10"
-                    <% if(ob.vendor_offer.listing.item.image_hashes){ %>
-                    style="background-image: url(<%- ob.serverUrl %>get_image?hash=<%- ob.vendor_offer.listing.item.image_hashes[0] %>&guid=<%-ob.vendor_offer.listing.id.guid %>), url(imgs/defaultBanner.png);"
-                    <% } else { %>
-                    style="background-image: url(imgs/defaultBanner.png);"
-                    <% } %>>
-                </div>
-              </a>
-            <div class="pad10left txt-unleaded fontSize13 textOpacity1 marginTop6">
-              <%- ob.vendor_order_confirmation.invoice.comments ? ob.vendor_order_confirmation.invoice.comments : polyglot.t('transactions.None') %>
-            </div>
-            <% if( ob.vendor_order_confirmation.invoice.shipping) { %>
-            <div class="pad10left txt-unleaded fontSize13 textOpacity1 marginTop12">
-              <strong><%= polyglot.t('transactions.EstimatedDelivery') %>:</strong>
-              <%= ob.vendor_order_confirmation.invoice.shipping.est_delivery ?
-              ob.vendor_order_confirmation.invoice.shipping.est_delivery : polyglot.t('transactions.None') %>
-            </div>
-            <div class="pad10left txt-unleaded fontSize13 textOpacity1 marginTop12">
-              <strong><%= polyglot.t('transactions.Shipper') %>:</strong>
-              <%= ob.vendor_order_confirmation.invoice.shipping.shipper ?
-              ob.vendor_order_confirmation.invoice.shipping.shipper : polyglot.t('transactions.None') %>
-            </div>
-            <div class="pad10left txt-unleaded fontSize13 textOpacity1 marginTop12">
-              <strong><%= polyglot.t('transactions.TrackingNumber') %>:</strong>
-              <%= ob.vendor_order_confirmation.invoice.shipping.tracking_number
-              ? ob.vendor_order_confirmation.invoice.shipping.tracking_number : polyglot.t('transactions.None') %>
-            </div>
-            <% } %>
-            <% if( ob.vendor_order_confirmation.invoice.content_source) { %>
-  <!--           <div class="txt-unleaded fontSize13 textOpacity75 marginTop4 noOverflow tooltip" data-tooltip="<%- ob.vendor_order_confirmation.invoice.content_source.url %>">
-              <%- ob.vendor_order_confirmation.invoice.content_source.url ?
-              ob.vendor_order_confirmation.invoice.content_source.url : polyglot.t('transactions.NoFileProvided') %>
-            </div> -->
-              <% if( ob.vendor_order_confirmation.invoice.content_source.password) { %>
-              <div class="pad10left txt-unleaded fontSize13 textOpacity75 marginTop4">
-                <%= polyglot.t('transactions.Password') %>:
-                <%= ob.vendor_order_confirmation.invoice.content_source.password ?
-                ob.vendor_order_confirmation.invoice.content_source.password : polyglot.t('transactions.None') %>
+            <a href="#userPage/<%- ob.vendor_offer.listing.id.guid %>/item/<%- ob.vendor_offer.listing.contract_id %>">
+              <div class="thumbnail thumbnail-large-slim pull-left marginRight10"
+                  <% if(ob.vendor_offer.listing.item.image_hashes){ %>
+                  style="background-image: url(<%- ob.serverUrl %>get_image?hash=<%- ob.vendor_offer.listing.item.image_hashes[0] %>&guid=<%-ob.vendor_offer.listing.id.guid %>), url(imgs/defaultBanner.png);"
+                  <% } else { %>
+                  style="background-image: url(imgs/defaultBanner.png);"
+                  <% } %>>
               </div>
-              <% }else{ %>
-              <div class="pad10left txt-unleaded fontSize13 textOpacity75 marginTop4">
-                <%= polyglot.t('transactions.Password') %>:
-                <%- polyglot.t('transactions.None') %>
+            </a>
+            <div class="pull-left">
+              <div class="txt-unleaded fontSize13 textOpacity1 marginTop6">
+                <%- ob.vendor_order_confirmation.invoice.comments ? ob.vendor_order_confirmation.invoice.comments : polyglot.t('transactions.None') %>
+              </div>
+              <% if( ob.vendor_order_confirmation.invoice.shipping) { %>
+              <div class="txt-unleaded fontSize13 textOpacity1 marginTop12">
+                <strong><%= polyglot.t('transactions.EstimatedDelivery') %>:</strong>
+                <%= ob.vendor_order_confirmation.invoice.shipping.est_delivery ?
+                ob.vendor_order_confirmation.invoice.shipping.est_delivery : polyglot.t('transactions.None') %>
+              </div>
+              <div class="txt-unleaded fontSize13 textOpacity1 marginTop12">
+                <strong><%= polyglot.t('transactions.Shipper') %>:</strong>
+                <%= ob.vendor_order_confirmation.invoice.shipping.shipper ?
+                ob.vendor_order_confirmation.invoice.shipping.shipper : polyglot.t('transactions.None') %>
+              </div>
+              <div class="txt-unleaded fontSize13 textOpacity1 marginTop12">
+                <strong><%= polyglot.t('transactions.TrackingNumber') %>:</strong>
+                <%= ob.vendor_order_confirmation.invoice.shipping.tracking_number
+                ? ob.vendor_order_confirmation.invoice.shipping.tracking_number : polyglot.t('transactions.None') %>
               </div>
               <% } %>
-            <% } %>
+              <% if( ob.vendor_order_confirmation.invoice.content_source) { %>
+                <% if( ob.vendor_order_confirmation.invoice.content_source.password) { %>
+                <div class="txt-unleaded fontSize13 textOpacity75 marginTop4">
+                  <%= polyglot.t('transactions.Password') %>:
+                  <%= ob.vendor_order_confirmation.invoice.content_source.password ?
+                  ob.vendor_order_confirmation.invoice.content_source.password : polyglot.t('transactions.None') %>
+                </div>
+                <% }else{ %>
+                <div class="txt-unleaded fontSize13 textOpacity75 marginTop4">
+                  <%= polyglot.t('transactions.Password') %>:
+                  <%- polyglot.t('transactions.None') %>
+                </div>
+                <% } %>
+              <% } %>
+            </div>
           </div>
           <% if( ob.vendor_order_confirmation.invoice.content_source && ob.vendor_order_confirmation.invoice.content_source.url ) { %>
           <div class="flexCol-4">
             <a href="<%- ob.vendor_order_confirmation.invoice.content_source.url %>" class="js-externalLink">
-              <div class="btn btn-txt floatRight custCol-secondary textOpacity1">
+              <div class="btn btn-txt pull-right custCol-secondary textOpacity1">
                 Open File <span class="ion-android-open fontSize10"></span>
               </div>
             </a>
@@ -793,7 +791,6 @@
           </div>
           <% if(ob.bitcoin_txs && ob.bitcoin_txs[0]){ %>
           <a href="https://live.blockcypher.com/btc-testnet/tx/<%- ob.bitcoin_txs[0].txid %>" class="noWrap js-externalLink positionAbsolute right10">
-          <!--<a href="https://blockchain.info/tx/<%- ob.bitcoin_txs[0].txid %>" class="noWrap js-externalLink positionAbsolute right10">-->
             <div class="btn btn-txt floatRight custCol-secondary textOpacity1">
               <%= polyglot.t('transactions.ViewOnBlockchain') %>
               <span class="ion-android-open fontSize10"></span>
@@ -805,7 +802,14 @@
           <div class="flexRow rowItem padding15 custCol-border borderBottom">
             <div class="txt-unleaded width100">
               <a href="#userPage/<%- ob.vendor_offer.listing.id.guid %>">
-                <div class="thumbnail thumbnail-large-slim floatLeft marginRight10" style="background-image: url(imgs/defaultUser.png);">
+                <div class="thumbnail thumbnail-large-slim floatLeft marginRight10"
+                <% if(ob.vendorAvatarURL && ob.transactionType == "purchases"){ %>
+                style="background-image: url(<%- ob.vendorAvatarURL %>), url(imgs/defaultUser.png);"
+                <% } else if(ob.transactionType == "sales"){ %>
+                style="background-image: url(<%- ob.avatarURL %>), url(imgs/defaultUser.png);"
+                <% } else { %>
+                style="background-image: url(imgs/defaultUser.png);"
+                <% } %>>
                 </div>
               </a>
               <div class="marginTop12 marginBottom4 fontSize14 noOverflow">
@@ -827,29 +831,19 @@
                 <strong><%= polyglot.t('Free') %></strong>
                 <% } %>
               </div>
-    <!--           <% _.each(ob.bitcoin_txs, function(tx, i){ %>
-                <% if(tx.type == "outgoing"){ %>
-                <div class="noOverflow width100 fontSize13 txt-fade">
-                  <div class="marginTop12 marginBottom4"><%= polyglot.t('transactions.transferReceipt') %>:</div>
-                  <div class="marginTop12 marginBottom4 fontSize10">
-                    <a href="https://blockchain.info/tx/<%= ob.bitcoin_txs[i].txid %>" class="noWrap js-externalLink">
-                      <%= ob.bitcoin_txs[i].txid %>
-                    </a>
-                  </div>
-                  <div>
-                    <a class="js-copyIncommingTx" data-tx="<%= ob.bitcoin_txs[i].txid %>">
-                      <i class="ion-clipboard"></i> <%= polyglot.t('transactions.copyTxid') %>
-                    </a>
-                  </div>
-                </div>
-                <% } %>
-              <% }); %> -->
             </div>
           </div>
           <div class="flexRow rowItem padding15 custCol-border borderBottom">
             <div class="txt-unleaded">
               <a href="#userPage/<%- ob.buyer_order.order.id.guid %>">
-                <div class="thumbnail thumbnail-large-slim floatLeft marginRight10" style="background-image: url(imgs/defaultUser.png);">
+                <div class="thumbnail thumbnail-large-slim floatLeft marginRight10"
+                  <% if(ob.avatarURL && ob.transactionType == "purchases"){ %>
+                  style="background-image: url(<%- ob.avatarURL %>), url(imgs/defaultUser.png);"
+                  <% } else if(ob.buyerAvatarURL && ob.transactionType == "sales"){ %>
+                  style="background-image: url(<%- ob.buyerAvatarURL %>), url(imgs/defaultUser.png);"
+                  <% } else { %>
+                  style="background-image: url(imgs/defaultUser.png);"
+                  <% } %>>
                 </div>
               </a>
               <div class="marginTop12 marginBottom4 fontSize14 noOverflow">

--- a/js/utils/templateHelpers.js
+++ b/js/utils/templateHelpers.js
@@ -3,7 +3,8 @@ var app = require('../App.js').getApp(),
 
 function cssImageUrl(hash, guid, fallback) {
   var base = app.serverConfig.getServerBaseUrl() + '/',
-      url = '';
+      url = '',
+      localURL = localStorage.getItem('userAvatar-'+guid);
 
   if (hash) {
     url = `url(${base}get_image?hash=${hash}`;
@@ -11,9 +12,9 @@ function cssImageUrl(hash, guid, fallback) {
     if (fallback) url +=  ', '
   }
 
-  if (!hash && guid) {
-    url = `url(${localStorage.getItem('userAvatar-'+guid)})`;
-    if (fallback) url +=  ', '
+  if (!hash && localURL) {
+    url = `url(${localURL})`;
+    if (url && fallback) url +=  ', '
   }
 
   if (fallback) {
@@ -26,4 +27,4 @@ function cssImageUrl(hash, guid, fallback) {
 module.exports = {
   cssImageUrl: cssImageUrl,
   moment: moment
-}
+};

--- a/js/utils/templateHelpers.js
+++ b/js/utils/templateHelpers.js
@@ -11,6 +11,11 @@ function cssImageUrl(hash, guid, fallback) {
     if (fallback) url +=  ', '
   }
 
+  if (!hash && guid) {
+    url = `url(${localStorage.getItem('userAvatar-'+guid)})`;
+    if (fallback) url +=  ', '
+  }
+
   if (fallback) {
     url += `url(${fallback})`;
   }

--- a/js/views/itemShortVw.js
+++ b/js/views/itemShortVw.js
@@ -32,6 +32,10 @@ module.exports = baseVw.extend({
       this.render();
     }
 
+    //store avatar reference in localStorage for other views
+    var localAvatar = this.model.get('avatarURL') || this.model.get('serverUrl')+"get_image?hash="+this.model.avatar_hash+"&guid="+this.model.get('guid');
+    localAvatar && localStorage.setItem('userAvatar-'+this.model.get('guid'), localAvatar);
+
     this.listenTo(window.obEventBus, "followUser", function(options){
       if (options.view === this || options.guid !== this.model.get('guid')) {
         return;

--- a/js/views/transactionModalVw.js
+++ b/js/views/transactionModalVw.js
@@ -69,7 +69,6 @@ module.exports = baseVw.extend({
     this.cCode = options.cCode;
     this.btAve = options.btAve; //average price in bitcoin for one unit of the user's currency
     this.bitcoinValidationRegex = options.bitcoinValidationRegex;
-    this.pageState = options.state; //state of the parent view
     this.tabState = options.tabState ;//active tab
     this.socketView = options.socketView;
     this.userModel = options.userModel;
@@ -110,7 +109,6 @@ module.exports = baseVw.extend({
       dataType: 'json',
       success: function (model, response, options) {
         self.model.set('displayJSON', JSON.stringify(model.toJSON(), null, 2));
-        //TODO set 'payout' here if the user has a payout from a dispute
         if(!response.invalidData && response.vendor_offer.listing){
           self.model.updateAttributes();
         } else {
@@ -140,6 +138,8 @@ module.exports = baseVw.extend({
     var self = this;
     $('.js-loadingModal').addClass("hide");
     this.model.set('status', this.status);
+    this.model.set('vendorAvatarURL', localStorage.getItem('userAvatar-'+this.model.get('vendor_offer').listing.id.guid));
+    this.model.set('buyerAvatarURL', localStorage.getItem('userAvatar-'+this.model.get('buyer_order').order.id.guid));
     //makde sure data is valid
     if(this.model.get('invalidData')){
       messageModal.show(window.polyglot.t('errorMessages.serverError', self.model.get('error')));

--- a/js/views/transactionModalVw.js
+++ b/js/views/transactionModalVw.js
@@ -138,8 +138,6 @@ module.exports = baseVw.extend({
     var self = this;
     $('.js-loadingModal').addClass("hide");
     this.model.set('status', this.status);
-    this.model.set('vendorAvatarURL', localStorage.getItem('userAvatar-'+this.model.get('vendor_offer').listing.id.guid));
-    this.model.set('buyerAvatarURL', localStorage.getItem('userAvatar-'+this.model.get('buyer_order').order.id.guid));
     //makde sure data is valid
     if(this.model.get('invalidData')){
       messageModal.show(window.polyglot.t('errorMessages.serverError', self.model.get('error')));

--- a/js/views/userShortVw.js
+++ b/js/views/userShortVw.js
@@ -30,6 +30,10 @@ module.exports = baseVw.extend({
       }
     });
 
+    //store avatar reference in localStorage for other views
+    var localAvatar = this.model.get('avatarURL') || this.model.get('serverUrl')+"get_image?hash="+this.model.avatar_hash+"&guid="+this.model.get('guid');
+    localAvatar && localStorage.setItem('userAvatar-'+this.model.get('guid'), localAvatar);
+
     this.render();        
   },
 


### PR DESCRIPTION
When avatars are loaded in the userShort view and the itemShort view, the url is stored in localStorage. This URL is retrieved in transactions and the chat (and any other place that uses the cssImage helper) if the avatar_hash isn't available.

Future enhancements:
- also store the avatar when the user view is loaded
- change the transaction templates to use cssImage instead of adding the url in the order model

Closes #1137
