### PR TITLE
Notif quick fixes

### DIFF
--- a/js/views/notificationsVw.js
+++ b/js/views/notificationsVw.js
@@ -22,6 +22,11 @@ module.exports = baseVw.extend({
     this.fetch = this.options.initialFetch;
     
     this.listenTo(this.collection, 'update', (cl, options) => {
+      if (!options.add) return;
+
+      // on first notification, we'll re-render
+      if (cl.length === 1) this.render();
+
       var $notifPage = $('<div />');
 
       // we're assuming the only additions will either be a batch of

--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -90,9 +90,13 @@ module.exports = baseVw.extend({
     });
 
     this.unreadNotifsViaSocket = 0;
+    this.fetchNotifsMarkedAsRead = 0;
 
-    this.listenTo(this.notificationsCl, 'reset update', (cl, options) => {
-      if (options.xhr) this.unreadNotifsViaSocket = 0;
+    this.listenTo(this.notificationsCl, 'reset update', function(cl, options) {
+      if (options.xhr) {
+        this.fetchNotifsMarkedAsRead = 0;
+        this.unreadNotifsViaSocket = 0;
+      }
 
       this.setNotificationCount(this.getUnreadNotifCount());
     });
@@ -164,7 +168,7 @@ module.exports = baseVw.extend({
 
       this.notificationsCl.add(
           __.extend({}, notif, { read: false })
-      )
+      );
 
       //prevent message spamming from one user
       if(!this.notificationsRecord[username]){
@@ -374,7 +378,8 @@ module.exports = baseVw.extend({
   },
 
   getUnreadNotifCount: function() {
-    return (this.unreadNotifsViaSocket + this.notificationsCl.getUnreadCount()) || 0;
+    return this.unreadNotifsViaSocket + this.notificationsCl.getUnreadCount() -
+      this.fetchNotifsMarkedAsRead || 0;
   },
 
   onNotifMenuOpen: function() {
@@ -407,7 +412,9 @@ module.exports = baseVw.extend({
       });
     }
 
-    this.setNotificationCount(0);    
+    this.fetchNotifsMarkedAsRead += unread.length - this.unreadNotifsViaSocket;
+    this.unreadNotifsViaSocket = 0;
+    this.setNotificationCount(this.getUnreadNotifCount());
   },
 
   onPopMenuNavClick: function(e) {


### PR DESCRIPTION
Fixes 2 issues:
1.) If you have no notifications to start with, upon the first notification, the menu would still be empty until page refresh.
2.) The notification count was off.

A potentially confusing thing with the notification count is that when you close the notification menu, it's only marking the unread notifications as read that are actually in the menu. If you have a large number of unread notifications that haven't been fetched via scroll-based paging, then those will not be marked as read. For example, you may have 24 unread notifications and upon a close of the menu, the badge may say 18, if only 6 unread had been loaded into the menu.

It also might be slightly confusing in that it's not dependent on if the user actually scrolls the unread notification into view. It's just a matter of if the notification is in the menu or not. For example, if the user has 10 unread notifications which have been loaded into the menu and they close the menu having only seen 6 of them, with the remaining 4 being below the fold, the badge will say 0, since all unread notifications existing in the menu will be marked as read.
