### PR TITLE
Mark notification as read

### DIFF
--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -236,6 +236,8 @@ module.exports = baseVw.extend({
 
   notificationClick: function(e) {
     this.closeNotificationsMenu();
+    
+    this.markNotificationAsRead(e.view)
   },
 
   render: function(){
@@ -355,6 +357,27 @@ module.exports = baseVw.extend({
   closeNotificationsMenu: function() {
     app.hideOverlay();
     this.$notifMenu.removeClass('popMenu-opened');
+  },
+  
+  markNotificationAsRead: function(view) {
+    if (view.model.get('read') === false) {
+      var formData = new FormData();
+      
+      view.model.set('read', true);
+      formData.append('id', view.model.get('id'));
+      
+      $.ajax({
+        url: app.serverConfig.getServerBaseUrl() + '/mark_notification_as_read',
+        type: 'POST',
+        contentType: false,
+        processData: false,
+        dataType: 'json',
+        data: formData
+      });
+      
+      this.fetchNotifsMarkedAsRead++;
+      this.setNotificationCount(this.getUnreadNotifCount());
+    }
   },
 
   isNotifMenuOpen: function() {


### PR DESCRIPTION
There was a bug in the notification system that wouldn't mark a clicked notification as read. This PR fixes it.
