### PR TITLE
ensuring onNotifMenuClose is called when programatically closing the …

### DIFF
--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -355,6 +355,7 @@ module.exports = baseVw.extend({
   closeNotificationsMenu: function() {
     app.hideOverlay();
     this.$notifMenu.removeClass('popMenu-opened');
+    this.onNotifMenuClose();
   },
 
   isNotifMenuOpen: function() {


### PR DESCRIPTION
…notifications menu

This fixes the issue discovered by @mariodian (https://github.com/OpenBazaar/OpenBazaar-Client/pull/1327), where a notification was not being marked as read when you clicked on the notification (and thereby closing the menu).
