### PR TITLE
Make certain textareas resizable

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -2897,6 +2897,7 @@ input[type="number"].fieldItem.fieldItem-withButton {
   padding: 15px;
   border: 2px solid transparent;
   color: #fff;
+  resize: vertical;
 }
 
 .fieldItem-textarea:focus {


### PR DESCRIPTION
I'm sitting here with my friend who has a store and we figured it's pain in the ass to add descriptions to listings due to non-resizable text areas. 

I don't know what was the reason to make it that way, but I propose "resize: vertical" for at least ".fieldItem-textarea" which is good enough for description in settings and listings (and I guess few other similar places).
