### PR TITLE
clearing badge count when it is 0

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -121,7 +121,7 @@ App.prototype.setUnreadCounts = function(notif, chat) {
   this._chatMessagesUnread = typeof chat === 'number' ? chat : this._chatMessagesUnread;
 
   this._awayCounts = this._notifUnread + this._chatMessagesUnread;
-  this._awayCounts && ipcRenderer.send('set-badge', this._awayCounts);
+  ipcRenderer.send('set-badge', this._awayCounts || '');
 };
 
 App.prototype.setUnreadNotifCount = function(count) {


### PR DESCRIPTION
*\* OSX only ***

Fixing issue where the task bar badge count was not being cleared when it was at 0.

@hoffmabc Perhaps you'd like to test this one since @jjeffryes love affair with **@bill_gates** precludes him :(
