### PR TITLE
Fixed links in user profile

### DIFF
--- a/js/templates/userPage.html
+++ b/js/templates/userPage.html
@@ -326,7 +326,7 @@
                 <div class="textOpacity75"><%= polyglot.t('Facebook') %></div>
                 <div>
                   <% if(ob.page.profile.social_accounts.facebook && ob.page.profile.social_accounts.facebook.username) { %>
-                    <a href="http://facebook.com/<%= ob.page.profile.social_accounts.facebook.username %>">
+                    <a href="https://facebook.com/<%= ob.page.profile.social_accounts.facebook.username %>">
                       <%= ob.page.profile.social_accounts.facebook.username %>
                     </a> <i class="ion-android-open fontSize10"></i>
                   <%}else{%>
@@ -348,7 +348,7 @@
                 <div class="textOpacity75"><%= polyglot.t('Twitter') %></div>
                 <div>
                   <% if(ob.page.profile.social_accounts.twitter && ob.page.profile.social_accounts.twitter.username) { %>
-                    <a href="http://twitter.com/<%= ob.page.profile.social_accounts.twitter.username %>">
+                    <a href="https://twitter.com/<%= ob.page.profile.social_accounts.twitter.username %>">
                       <%= ob.page.profile.social_accounts.twitter.username %>
                     </a> <i class="ion-android-open fontSize10"></i>
                   <%}else{%>
@@ -370,7 +370,9 @@
                 <div class="textOpacity75"><%= polyglot.t('Instagram') %></div>
                 <div>
                   <% if(ob.page.profile.social_accounts.instagram && ob.page.profile.social_accounts.instagram.username) { %>
-                    <%= ob.page.profile.social_accounts.instagram.username %>
+                    <a href="https://instagram.com/<%= ob.page.profile.social_accounts.instagram.username %>">
+                      <%= ob.page.profile.social_accounts.instagram.username %>
+                    </a> <i class="ion-android-open fontSize10"></i>
                   <%}else{%>
                     <%= polyglot.t('NotProvided') %>
                   <%}%>
@@ -390,7 +392,9 @@
                 <div class="textOpacity75"><%= polyglot.t('Snapchat') %></div>
                 <div>
                   <% if(ob.page.profile.social_accounts.snapchat && ob.page.profile.social_accounts.snapchat.username) { %>
-                    <%= ob.page.profile.social_accounts.snapchat.username %>
+                    <a href="https://snapchat.com/add/<%= ob.page.profile.social_accounts.snapchat.username %>">
+                      <%= ob.page.profile.social_accounts.snapchat.username %>
+                    </a> <i class="ion-android-open fontSize10"></i>
                   <%}else{%>
                     <%= polyglot.t('NotProvided') %>
                   <%}%>


### PR DESCRIPTION
I added clickable URLs for Instagram and Snapchat.

It's also a good security practice to use https instead of http, so I forced it for all social networks in the user profile. I hope there isn't any specific reason that http was chosen over https?
