### PR TITLE
Make description titles look cleaner by adding top margin

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -1211,6 +1211,14 @@ h5 {
   font-size: 15px;
 }
 
+.fieldItem-textarea h2, .fieldItem-textarea h3, .editableContent h2, .editableContent h3 {
+  margin-top: 30px;
+}
+
+.fieldItem-textarea h2:first-child, .fieldItem-textarea h3:first-child, .editableContent h2:first-child, .editableContent h3:first-child {
+  margin-top: 0px;
+}
+
 .note {
   /* use for instructions and incidental text */
   /*font-style: italic;*/

--- a/js/templates/userPage.html
+++ b/js/templates/userPage.html
@@ -257,7 +257,7 @@
               </a>
             <%}%>
             <% if(ob.page.profile.about) { %>
-             <p class="js-userAbout margin0 flexContainer editableContent"><%= ob.page.profile.displayAbout %></p>
+             <div class="js-userAbout margin0 flexContainer editableContent"><%= ob.page.profile.displayAbout %></div>
             <%}else{%>
               <span class="textOpacity75"><%= polyglot.t('AboutEmpty') %></span>
             <%}%>


### PR DESCRIPTION
I added a top margin to h2, h3 titles in description on the user page and in listings. This visually separates each section that the title belong to.
### Before

![screen shot 2016-04-14 at 6 04 42 pm](https://cloud.githubusercontent.com/assets/3636406/14525245/29f2dc9e-026f-11e6-8b8e-ab83f3d0f810.png)
### After

![screen shot 2016-04-14 at 6 22 22 pm](https://cloud.githubusercontent.com/assets/3636406/14525280/493a5974-026f-11e6-87f7-b85b3f663aab.png)

Top margin isn't added to the top most title because it's unnecessary.
