### PR TITLE
Fix overflow issue with long text in textarea

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -2956,6 +2956,10 @@ input[type="number"].fieldItem.fieldItem-withButton {
   padding: 15px;
   border: 2px solid transparent;
   color: #fff;
+  overflow-y: scroll;
+}
+.fieldItem-textarea p:last-of-type {
+  margin: 0;
 }
 
 .fieldItem-textarea:focus {


### PR DESCRIPTION
A text longer than the height of textarea would get off the form field.

![screen shot 2016-04-15 at 1 56 10 am](https://cloud.githubusercontent.com/assets/3636406/14538465/78f577a4-02ae-11e6-8f99-bf173d22a749.png)

This PR adds a scrollbar to the textarea.
