### PR TITLE
fixing return outside of function that crashes client

### DIFF
--- a/main.js
+++ b/main.js
@@ -245,7 +245,8 @@ var iShouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory)
   }
   return true;
 });
-if(iShouldQuit){app.quit();return;}
+
+if (iShouldQuit) app.quit();
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {


### PR DESCRIPTION
At least on my system, the client was crashing on startup because there was a `return` statement in main.js outside of a function.
