### PR TITLE
Disable Purchase on Own Item

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -644,6 +644,7 @@
   },
   "buyFlow": {
     "PayForOrder": "Pay for Order",
+    "BuyOwnProductMsg": "You can't buy your own listing",
     "NeedTempAddress": "I need a temporary Bitcoin address",
     "NeedTempAddressHelper": "Please bookmark the url to your temporary bitcoin address",
     "CantFindAddress": "I can't find my bitcoin address",

--- a/js/templates/buyWizard.html
+++ b/js/templates/buyWizard.html
@@ -529,10 +529,16 @@
               <span class="ion-chevron-left fontSize10 marginRight2 textOpacity75"></span>
               <%= polyglot.t('Back') %>
             </a>
+            <% if(ob.ownPage){ %>
+            <div class="btn btn-bar btn-half custCol-secondary custCol-border-primary borderBottomRightRaidus3 disabled">
+              <%= polyglot.t('buyFlow.BuyOwnProductMsg') %>
+            </div>
+            <% } else { %>
             <a class="btn btn-bar btn-half  js-buyWizardSendPurchase custCol-secondary custCol-border-primary borderBottomRightRaidus3">
               <%= polyglot.t('buyFlow.PayForOrder') %>
               <span class="ion-chevron-right fontSize10 marginLeft2 textOpacity75"></span>
             </a>
+            <% } %>
             <span class="btn btn-bar btn-half disabled js-buyWizardPendingMsg hide custCol-secondary custCol-border-primary borderBottomRightRaidus3"><%= polyglot.t('PaymentPending') %></span>
             <a class="btn btn-bar btn-wide  js-buyWizardCloseSummary custCol-secondary borderBottomLeftRaidus3 borderBottomRightRaidus3 hide"><%= polyglot.t('Close') %></a>
           </div>


### PR DESCRIPTION
The purchase button at the end of the purchase flow is replaced by a "you can't buy your own listing" message if it's your own page.

Closes #1492
