### PR TITLE
Add store reviews

### DIFF
--- a/js/templates/item.html
+++ b/js/templates/item.html
@@ -154,7 +154,7 @@
           <span class="ion-android-list fontSize12 marginRight2 textOpacity1"></span>
           <%= polyglot.t('Description') %>
         </a>
-        <a class="btn btn-bar btn-tab custCol-secondary js-reviewsTab js-tab paddingRight18 <% ob.activeTab === 'reviews' && print('active') %>">
+        <a class="btn btn-bar btn-tab custCol-secondary js-itemReviewsTab js-tab paddingRight18 <% ob.activeTab === 'itemreviews' && print('active') %>">
           <span class="ion-android-star fontSize11 marginRight2 textOpacity1"></span>
           <%= polyglot.t('Reviews') %>
           <% if (!ob.fetchingRatings) { %>
@@ -173,7 +173,7 @@
           </div>
         </div>
       </div>
-      <div class="flexContainer flex-border custCol-primary minHeight300 textOpacity75 js-reviews js-tabTarg <% ob.activeTab !== 'reviews' && print('hide') %>">
+      <div class="flexContainer flex-border custCol-primary minHeight300 textOpacity75 js-itemreviews js-tabTarg <% ob.activeTab !== 'itemreviews' && print('hide') %>">
         <% if (ob.fetchingRatings) { %>
         <div class="padding20 marginBottom12 width100 alignCenter">
           <div class="spinnerWrapper">

--- a/js/templates/ratingStars.html
+++ b/js/templates/ratingStars.html
@@ -1,15 +1,13 @@
 <% for (var i=0; i < ob.rating; i++) { %>
-<div class="inlineBlock positionRelative">
   <% if (Math.floor(ob.rating) === i) { %>
-    <span class="ion-android-star unfilled"></span>
-    <span class="ion-android-star textOpacity1 positionAbsolute noOverflow" style="top:0;bottom:0;left:0;right:0;width:<%= ((ob.rating % 1) * 100) + '%'%>"></span>
-  <% } else { %>
-    <span class="ion-android-star textOpacity1"></span>
-  <% } %>
-</div>
-<% } %>
-<% for (var i=0; i < 5 - ob.rating; i++) { %>
 <div class="inlineBlock positionRelative">
   <span class="ion-android-star unfilled"></span>
+  <span class="ion-android-star textOpacity1 positionAbsolute noOverflow" style="top:0;bottom:0;left:0;right:0;width:<%= ((ob.rating % 1) * 100) + '%'%>"></span>
 </div>
+  <% } else { %>
+<span class="ion-android-star textOpacity1"></span>
+  <% } %>
+<% } %>
+<% for (var i=0; i < 5 - ob.rating; i++) { %>
+<span class="ion-android-star unfilled"></span>
 <% } %>

--- a/js/templates/review.html
+++ b/js/templates/review.html
@@ -1,61 +1,47 @@
 <div class="rowItem padding2015">
-  <div class="table custCol-text">
+  <div class="table custCol-text marginLeft15">
     <div>
-      <div class="marginLeft15 marginTop2">
-        <div class="marginLeft15 marginTop2">
-        </div>
-        <div class="marginLeft15 marginTop2">
-          <div class="clearfix">
-            <div class="pull-left">
-              <% print(ob.starsTmpl({ rating: ob.feedback })) %>
-              (<%= ob.feedback %>/5)
-            </div>
-            <% if(ob.address){ %>
-            <div class="pull-right">
-              <% if(config.testnet){ %>
-                <a href="https://live.blockcypher.com/btc-testnet/address/<%- ob.address %>" class="noWrap">
-              <% }else{ %>
-              <a href="https://live.blockcypher.com/btc/address/<%- ob.address %>" class="noWrap">
-                <% } %>
-                <div class="btn btn-txt floatRight custCol-secondary textOpacity1">
-                  <%= polyglot.t('transactions.ViewOnBlockchain') %>
-                  <span class="ion-android-open fontSize10"></span>
-                </div>
-              </a>
-            </div>
-            <% } %>
+      <div class="marginTop2">
+        <div class="clearfix">
+          <div class="pull-left">
+            <% print(ob.starsTmpl({ rating: ob.feedback })) %>
+            (<%= ob.feedback %>/5)
           </div>
-          <p class="fontSize14 textWeightNormal clamp4 marginTop9"><%= ob.review %></p>
+          <% if(ob.address){ %>
+          <div class="pull-right">
+            <% if(config.testnet){ %>
+              <a href="https://live.blockcypher.com/btc-testnet/address/<%- ob.address %>" class="noWrap">
+            <% }else{ %>
+            <a href="https://live.blockcypher.com/btc/address/<%- ob.address %>" class="noWrap btn btn-txt floatRight custCol-secondary textOpacity1">
+              <% } %>
+                <%= polyglot.t('transactions.ViewOnBlockchain') %>
+                <span class="ion-android-open fontSize10"></span>
+            </a>
+          </div>
+          <% } %>
         </div>
+        <p class="fontSize14 textWeightNormal clamp4 marginTop9"><%= ob.review %></p>
       </div>
       <div class="marginLeft15 pull-right">
-        <div class="floatLeft marginRight15" style="width: 200px">
-          <div class="fontSize14">
-            <div><%= polyglot.t('transactions.Quality') %> (<%= ob.quality %>/5)</div>
-            <div>
-              <% print(ob.starsTmpl({ rating: ob.quality })) %>
-            </div>
+        <div class="floatLeft marginRight15 fontSize14" style="width: 200px">
+          <div><%= polyglot.t('transactions.Quality') %> (<%= ob.quality %>/5)</div>
+          <div>
+            <% print(ob.starsTmpl({ rating: ob.quality })) %>
           </div>
-          <div class="fontSize14 marginTop9">
-            <div><%= polyglot.t('transactions.MatchedDescription') %> (<%= ob.description %>/5)</div>
-            <div>
-              <% print(ob.starsTmpl({ rating: ob.description })) %>
-            </div>
+          <div class="marginTop9"><%= polyglot.t('transactions.MatchedDescription') %> (<%= ob.description %>/5)</div>
+          <div>
+            <% print(ob.starsTmpl({ rating: ob.description })) %>
           </div>
         </div>
-        <div class="floatLeft" style="width: 200px">
-          <div class="fontSize14">
-            <div><%= polyglot.t('transactions.DeliverySpeed') %> (<%= ob.delivery_time %>/5)</div>
-            <div>
-              <% print(ob.starsTmpl({ rating: ob.delivery_time })) %>
-            </div>            
-          </div>
-          <div class="fontSize14 marginTop9">
-            <div><%= polyglot.t('transactions.CustomerService') %> (<%= ob.customer_service %>/5)</div>
-            <div>
-              <% print(ob.starsTmpl({ rating: ob.customer_service })) %>
-            </div>            
-          </div>        
+        <div class="floatLeft fontSize14" style="width: 200px">
+          <div><%= polyglot.t('transactions.DeliverySpeed') %> (<%= ob.delivery_time %>/5)</div>
+          <div>
+            <% print(ob.starsTmpl({ rating: ob.delivery_time })) %>
+          </div>            
+          <div class="marginTop9"><%= polyglot.t('transactions.CustomerService') %> (<%= ob.customer_service %>/5)</div>
+          <div>
+            <% print(ob.starsTmpl({ rating: ob.customer_service })) %>
+          </div>            
         </div>
       </div>
     </div>

--- a/js/templates/userPage.html
+++ b/js/templates/userPage.html
@@ -258,6 +258,13 @@
       <span class="pill fontSize12 textOpacity75 marginLeft2 js-userFollowerCount">...</span>
     </a>
     <% if(ob.page.profile.vendor) { %>
+    <a class="btn btn-bar btn-tab custCol-secondary js-reviewsTab js-tab paddingRight18">
+      <span class="ion-android-star fontSize11 marginRight2 textOpacity1"></span>
+      <%= polyglot.t('Reviews') %>
+      <span class="pill fontSize12 textOpacity75 marginLeft2 js-userReviewsCount">...</span>
+    </a>
+    <% } %>
+    <% if(ob.page.profile.vendor) { %>
     <a class="btn btn-bar btn-tab custCol-secondary js-storeTab js-tab paddingRight18">
       <span class="ion-ios-cart fontSize11 marginRight2 textOpacity1"></span>
       <%= polyglot.t('Store') %>
@@ -425,6 +432,13 @@
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+    <div class="flexContainer flex-border custCol-primary js-reviews js-tabTarg hide minHeight650" id="searchReviews">
+      <div class="flexRow js-list6">
+        <div class="padding10 width100 alignCenter js-loadingMsg borderBottom">
+          <i class="ion-android-sync spinner textSize24px textOpacity50"></i>
         </div>
       </div>
     </div>

--- a/js/views/itemVw.js
+++ b/js/views/itemVw.js
@@ -13,7 +13,7 @@ module.exports = baseVw.extend({
 
   events: {
     'click .js-descriptionTab': 'descriptionClick',
-    'click .js-reviewsTab': 'reviewsClick',
+    'click .js-itemReviewsTab': 'reviewsClick',
     'click .js-shippingTab': 'shippingClick',
     'click .js-buyButton': 'buyClick',
     'click .js-photoGallery': 'photoGalleryClick',
@@ -147,7 +147,7 @@ module.exports = baseVw.extend({
   },
 
   reviewsClick: function(e){
-    this.setTab('reviews');
+    this.setTab('itemreviews');
   },
 
   shippingClick: function(e){
@@ -176,7 +176,7 @@ module.exports = baseVw.extend({
   },
 
   clickItemRating: function(e) {
-    this.setTab('reviews');
+    this.setTab('itemreviews');
     $('#obContainer').animate({
       scrollTop: this.$('.js-reviewsContainer').offset().top
     }, 200);

--- a/js/views/reviewsVw.js
+++ b/js/views/reviewsVw.js
@@ -13,7 +13,7 @@ module.exports = baseVw.extend({
   events: {
   },
 
-  VIEWS_PER_BATCH: 25,
+  VIEWS_PER_BATCH: 10,
 
   MAX_VIEWS: 1500,
 


### PR DESCRIPTION
There is a new tab called "Reviews" on the user page that lists all the store reviews.

![screen shot 2016-05-10 at 1 26 35 pm](https://cloud.githubusercontent.com/assets/3636406/15136351/634e26b2-16b3-11e6-9387-1d6ae4a42b5d.png)

There's an issue though I've already discussed with @jjeffryes. If the list is too long (15-20 and more reviews), switching tabs from let's say "Followers" back to Reviews is little bit slower (~1 second). 

This also applies to the current list of reviews under a listing, so it seems this issue wasn't introduced with my code.

I spent hours figuring out what's the problem and I think it's because the DOM is just too big (around 6k lines while on the user page with a store enabled). However, if I remove star ratings altogether it's **way** faster. I also tried leaving just an overall score and removing all other stars and it helped a lot.

I got rid of few unnecessary divs to speed it up a little and I also changed the "VIEWS_PER_BATCH" from 25 to 10 so switching the tab is "instant".

Please discuss if this kind of feature is desired (I know there are little different plans for store reviews) and if yes, I'd be glad if someone could help me figure out the issue. Thanks.
