### PR TITLE
Optimize jQuery selectors

### DIFF
--- a/js/views/buyDetailsVw.js
+++ b/js/views/buyDetailsVw.js
@@ -122,7 +122,7 @@ module.exports = Backbone.View.extend({
   lockForm: function(){
     "use strict";
     this.$('.js-buyWizardQuantity').prop('disabled', true);
-    this.$('#buyWizardQuantity .numberSpinnerUp, #buyWizardQuantity .numberSpinnerDown').addClass('hide');
+    this.$('#buyWizardQuantity').find('.numberSpinnerUp,.numberSpinnerDown').addClass('hide');
   },
 
   goToPurchases: function(){

--- a/js/views/chatConversationVw.js
+++ b/js/views/chatConversationVw.js
@@ -226,7 +226,7 @@ module.exports = baseVw.extend({
         }))
       );
 
-      this.$('.chatConversationMessage textarea').focus();
+      this.$('.chatConversationMessage').find('textarea').focus();
       this.$messagesScrollContainer = this.$('.chatConversationContent');
       this.$messagesScrollContainer.on('scroll', this.scrollHandler);
       this.$loadingSpinner = this.$messagesScrollContainer.find('.js-loadingSpinner');

--- a/js/views/homeVw.js
+++ b/js/views/homeVw.js
@@ -101,9 +101,9 @@ module.exports = baseVw.extend({
 
     // after 8 seconds, if no listings are found, display the no results found message
     this.noResultsTimeout = window.setTimeout(function() {
-      if ($('.homeGridItems .gridItem').length === 0){
+      if ($('.homeGridItems').find('.gridItem').length === 0){
         self.$el.find('.js-loadingMessage').removeClass('fadeOut');
-        self.$el.find('.js-loadingMessage .spinner').addClass('fadeOut');
+        self.$el.find('.js-loadingMessage').find('.spinner').addClass('fadeOut');
         self.$el.find('.js-loadingText').html(
           window.polyglot.t('discover.' + (self.searchItemsText ? 'noTaggedResults' : 'noResults'))
         );
@@ -506,7 +506,7 @@ module.exports = baseVw.extend({
       text = count + ' blocked item' + (count !== 1 ? 's' : '') + ' not shown';
     }
 
-    this.$listingsBlockedCount = this.$listingsBlockedCount || this.$('.homeGridItems .js-blocked-listings-count');
+    this.$listingsBlockedCount = this.$listingsBlockedCount || this.$('.homeGridItems').find('.js-blocked-listings-count');
     this.$listingsBlockedCount.text(text);
   },
 

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -228,7 +228,7 @@ module.exports = baseVw.extend({
     this.$el.find('.js-shippingRow input')
         .prop({disabled: false, require: true});
     //if chosen selector started hidden, it will be too narrow
-    $('.js-shippingRow .chosen-container').css({width: '100%'});
+    $('.js-shippingRow').find('.chosen-container').css({width: '100%'});
   },
 
   changeType: function(e) {

--- a/js/views/onboardingModal.js
+++ b/js/views/onboardingModal.js
@@ -389,7 +389,7 @@ module.exports = baseModal.extend({
       avatarUpload.resolve();
     }
 
-    this.$('.js-followHandles [data-handle]:checked').each(function(e) {
+    this.$('.js-followHandles').find('[data-handle]:checked').each(function(e) {
       followHandles.push($(this).data('handle'));
     });
 

--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -317,19 +317,20 @@ module.exports = baseVw.extend({
   },
 
   showAboutModal: function(e){
-
+    var $aboutModal = $('.js-aboutModal');
+    
     this.cleanNav();
 
     // display the modal
     $('.js-aboutModalHolder').fadeIn(300);
 
     // set the active tab
-    $('.js-aboutModal .navBar .btn.btn-bar').removeClass('active');
+    $aboutModal.find('.navBar').find('.btn.btn-bar').removeClass('active');
     $('.js-about-mainTab').addClass('active');
 
     // set the active section
-    $('.js-aboutModal .modal-section').addClass('hide');
-    $('.js-aboutModal .js-modalAboutMain').removeClass('hide');
+    $aboutModal.find('.modal-section').addClass('hide');
+    $aboutModal.find('.js-modalAboutMain').removeClass('hide');
 
     // blur the container for extra focus
     $('#obContainer').addClass('blur');
@@ -341,17 +342,19 @@ module.exports = baseVw.extend({
   },
 
   showSupportModal: function(e){
+    var $aboutModal = $('.js-aboutModal');
+    
     $('.js-aboutModalHolder').fadeIn(300);
-    $('.js-aboutModal .navBar .btn.btn-bar').removeClass('active');
+    $aboutModal.find('.navbar').find('.btn.btn-bar').removeClass('active');
     $('.js-about-donationsTab').addClass('active');
-    $('.js-aboutModal .modal-section').addClass('hide');
-    $('.js-aboutModal .js-modalAboutSupport').removeClass('hide');
+    $aboutModal.find('modal-section').addClass('hide');
+    $aboutModal.find('js-modalAboutSupport').removeClass('hide');
     $('#obContainer').addClass('blur');
   },
 
   aboutModalTabClick: function(e){
     var tab = $(e.currentTarget).data('tab');
-    $('.js-aboutModal .btn-tab').removeClass('active');
+    $('.js-aboutModal').find('.btn-tab').removeClass('active');
     $(e.currentTarget).addClass('active');
 
     switch(tab) {

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -454,9 +454,9 @@ module.exports = Backbone.View.extend({
     language.html(language_str);
 
     //set moderator status
-    this.$('#moderatorForm input[name=moderator]').val([String(moderatorStatus)]);
+    this.$('#moderatorForm').find('input[name=moderator]').val([String(moderatorStatus)]);
 
-    this.$('#advancedForm input[name=smtp_mo]').val([String(moderatorStatus)]);
+    this.$('#advancedForm').find('input[name=smtp_mo]').val([String(moderatorStatus)]);
   },
 
   showModeratorFeeHolder: function(){
@@ -822,10 +822,10 @@ module.exports = Backbone.View.extend({
     var self = this,
         form = this.$el.find("#storeForm"),
         settingsData = {},
-        moderatorsNew = this.$el.find('#storeForm .js-settingsNewMods .js-userShortView input:checked'),
+        moderatorsNew = this.$el.find('#storeForm').find('.js-settingsNewMods').find('.js-userShortView').find('input:checked'),
         moderatorList = this.userModel.get('moderator_guids'),
         manualModList,
-        moderatorsUnChecked = this.$('#storeForm .js-settingsCurrentMods .js-userShortView input:not(:checked)'),
+        moderatorsUnChecked = this.$('#storeForm').find('.js-settingsCurrentMods').find('.js-userShortView').find('input:not(:checked)'),
         onFail,
         $saveBtn = this.$('.js-saveStore');
 
@@ -972,7 +972,7 @@ module.exports = Backbone.View.extend({
 
     $saveBtn.addClass('loading');
 
-    localStorage.setItem('AdditionalPaymentData',  this.$('#advancedForm input[name=additionalPaymentData]:checked').val());
+    localStorage.setItem('AdditionalPaymentData',  this.$('#advancedForm').find('input[name=additionalPaymentData]:checked').val());
     
     saveToAPI(form, this.userModel.toJSON(), self.serverUrl + "settings", function(){
       app.statusBar.pushMessage({
@@ -1033,7 +1033,7 @@ module.exports = Backbone.View.extend({
   },
 
   toggleFancyStyles: function(){
-    if($('#advancedForm input[name="notFancy"]').prop('checked')){
+    if($('#advancedForm').find('input[name="notFancy"]').prop('checked')){
       $('html').addClass('notFancy');
       localStorage.setItem('notFancy', "true");
     } else {
@@ -1043,7 +1043,7 @@ module.exports = Backbone.View.extend({
   },
 
   toggleTestnet: function(){
-    window.config.setTestnet($('#advancedForm input[name="useTestnet"]').prop('checked'));
+    window.config.setTestnet($('#advancedForm').find('input[name="useTestnet"]').prop('checked'));
     window.location.reload();
   },
 

--- a/js/views/storeWizardVw.js
+++ b/js/views/storeWizardVw.js
@@ -185,7 +185,7 @@ module.exports = Backbone.View.extend({
     "use strict";
     var self = this,
         profileForm = this.$el.find('#storeWizardForm'),
-        moderatorsChecked = $('.js-storeWizardModeratorList input:checked'),
+        moderatorsChecked = $('.js-storeWizardModeratorList').find('input:checked'),
         userProfile = this.model.get('page').profile,
         modList = [],
         wizData = {},

--- a/js/views/transactionsVw.js
+++ b/js/views/transactionsVw.js
@@ -232,7 +232,7 @@ module.exports = baseVw.extend({
         tabTarget = tab.data("tab");
 
     this.filterBy = tab.val();
-    this.$('.js-'+tabTarget+' .search').val("");
+    this.$('.js-'+tabTarget).find('.search').val("");
     switch(tabTarget){
       case "purchases":
         this.renderTab("purchases", this.purchasesCol, this.purchasesWrapper);

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -404,20 +404,22 @@ module.exports = baseVw.extend({
           console.log(errorMessage);
         }
       });
+      
+      var $userPageHeader = $('.user-page-header');
 
       $("#obContainer").scroll(function(){
         if ($(this).scrollTop() > 400 && self.slimVisible === false ) {
           self.slimVisible = true;
           $('.user-page-header-slim').addClass('textOpacity1').addClass('top70');
-          $('.user-page-header').removeClass('shadow-inner1').addClass('zIndex4');
-          $('.user-page-header .rowItem').hide();
+          $userPageHeader.removeClass('shadow-inner1').addClass('zIndex4');
+          $userPageHeader.find('.rowItem').hide();
           $('.user-page-navigation-buttons').addClass('positionFixed positionTop68');
         }
         if ($(this).scrollTop() < 400 && self.slimVisible === true ) {
           self.slimVisible = false;
           $('.user-page-header-slim').removeClass('top70');
-          $('.user-page-header').addClass('shadow-inner1').removeClass('zIndex4');
-          $('.user-page-header .rowItem').show();
+          $userPageHeader.addClass('shadow-inner1').removeClass('zIndex4');
+          $userPageHeader.find('.rowItem').show();
           $('.user-page-navigation-buttons').removeClass('positionFixed positionTop68');
         }
       });
@@ -1028,7 +1030,7 @@ module.exports = baseVw.extend({
 
   storeTabClick: function(e) {
     if (this.$el.find('.js-categories').val() != "all"){
-        $(".js-categories option[value='all']").attr("selected", "selected");
+        $(".js-categories").find("option[value='all']").attr("selected", "selected");
         this.categoryChanged();
     }
 
@@ -1105,26 +1107,29 @@ module.exports = baseVw.extend({
 
   displayCustomizePrimaryColor: function(e) {
     "use strict";
+    
+    var $customizePrimaryColorRecommendations = this.$el.find('.customizePrimaryColorRecommendations'),
+        $customColorChoice = $customizePrimaryColorRecommendations.find('.customColorChoice');
 
     $('#primary_color').colpickHide();
 
-    if(this.$el.find('.customizePrimaryColorRecommendations').hasClass('width270')){
-      this.$el.find('.customizePrimaryColorRecommendations').removeClass('width270');
+    if($customizePrimaryColorRecommendations.hasClass('width270')){
+      $customizePrimaryColorRecommendations.removeClass('width270');
     }else{
       $('.seeTooltip').hide();
 
       // set recommendations
-      this.$el.find('.customColorChoice').css('background','#fff'); // reset to white to give a cool transition
-      this.$el.find('.customizePrimaryColorRecommendations .customColorChoice:first').css('background','transparent'); // set to transparent
-      this.$el.find('.customizePrimaryColorRecommendations .customColorChoice:nth-child(2)').css('background', recommendedPrimaryColors[Math.floor(Math.random() * recommendedPrimaryColors.length)]); // random colors to start
-      this.$el.find('.customizePrimaryColorRecommendations .customColorChoice:nth-child(3)').css('background', recommendedPrimaryColors[Math.floor(Math.random() * recommendedPrimaryColors.length)]); // random colors to start
-      this.$el.find('.customizePrimaryColorRecommendations .customColorChoice:nth-child(4)').css('background', recommendedPrimaryColors[Math.floor(Math.random() * recommendedPrimaryColors.length)]); // random colors to start
-      this.$el.find('.customizePrimaryColorRecommendations .customColorChoice:nth-child(5)').css('background', recommendedPrimaryColors[Math.floor(Math.random() * recommendedPrimaryColors.length)]); // random colors to start
-      this.$el.find('.customizePrimaryColorRecommendations .customColorChoice:nth-child(6)').css('background', recommendedPrimaryColors[Math.floor(Math.random() * recommendedPrimaryColors.length)]); // random colors to start
-      this.$el.find('.customizePrimaryColorRecommendations .customColorChoice:last').css('background', recommendedPrimaryColors[Math.floor(Math.random() * recommendedPrimaryColors.length)]); // random colors to start
+      $customColorChoice.css('background','#fff'); // reset to white to give a cool transition
+      $customColorChoice.first().css('background','transparent'); // set to transparent
+      
+      for (var i = 2; i <= 6; i++) {
+        $customColorChoice.eq(i).css('background', recommendedPrimaryColors[Math.floor(Math.random() * recommendedPrimaryColors.length)]); // random colors to start
+      }
+
+      $customColorChoice.last().css('background', recommendedPrimaryColors[Math.floor(Math.random() * recommendedPrimaryColors.length)]); // random colors to start
 
       // slide background_color recommendations out + hide others
-      this.$el.find('.customizePrimaryColorRecommendations').addClass('width270');
+      $customizePrimaryColorRecommendations.addClass('width270');
       this.$el.find('.customizeSecondaryColorRecommendations').removeClass('width270');
       this.$el.find('.customizeBackgroundColorRecommendations').removeClass('width270');
       this.$el.find('.customizeTextColorRecommendations').removeClass('width270');
@@ -1133,26 +1138,29 @@ module.exports = baseVw.extend({
 
   displayCustomizeSecondaryColor: function(e) {
     "use strict";
-    var primaryColor = this.model.get('page').profile.primary_color;
+    var $customizeSecondaryColorRecommendations = this.$el.find('.customizeSecondaryColorRecommendations'),
+        $customColorChoice = $customizeSecondaryColorRecommendations.find('.customColorChoice'),
+        primaryColor = this.model.get('page').profile.primary_color,
+        shades = [-0.25, -0.15, -0.1, 0.1, 0.15];
 
     $('#secondary_color').colpickHide();
 
-    if(this.$el.find('.customizeSecondaryColorRecommendations').hasClass('width270')){
-      this.$el.find('.customizeSecondaryColorRecommendations').removeClass('width270');
+    if($customizeSecondaryColorRecommendations.hasClass('width270')){
+      $customizeSecondaryColorRecommendations.removeClass('width270');
     }else{
       // set recommendations
-      this.$el.find('.customColorChoice').css('background','#fff');  // reset to white to give a cool transition
-      this.$el.find('.customizeSecondaryColorRecommendations .customColorChoice:first').css('background','transparent'); // set to transparent
-      this.$el.find('.customizeSecondaryColorRecommendations .customColorChoice:nth-child(2)').css('background', shadeColor2(primaryColor, -0.25)); // 20% lighter than primary_color
-      this.$el.find('.customizeSecondaryColorRecommendations .customColorChoice:nth-child(3)').css('background', shadeColor2(primaryColor, -0.15)); // 15% lighter than primary_color
-      this.$el.find('.customizeSecondaryColorRecommendations .customColorChoice:nth-child(4)').css('background', shadeColor2(primaryColor, -0.1)); // 10% lighter than primary_color
-      this.$el.find('.customizeSecondaryColorRecommendations .customColorChoice:nth-child(5)').css('background', shadeColor2(primaryColor, 0.1)); // 10% darker than primary_color
-      this.$el.find('.customizeSecondaryColorRecommendations .customColorChoice:nth-child(6)').css('background', shadeColor2(primaryColor, 0.15)); // 15% darker than primary_color
-      this.$el.find('.customizeSecondaryColorRecommendations .customColorChoice:last').css('background', shadeColor2(primaryColor, 0.20)); // 25% darker than primary_color
+      $customColorChoice.css('background','#fff');  // reset to white to give a cool transition
+      $customColorChoice.first().css('background','transparent'); // set to transparent
+
+      for (var i = 2; i <= 6; i++) {
+        $customColorChoice.eq(i).css('background', shadeColor2(primaryColor, shades[i-2]));
+      }
+
+      $customColorChoice.last().css('background', shadeColor2(primaryColor, 0.20)); // 25% darker than primary_color
 
       // slide secondary_color recommendations out + hide others
       this.$el.find('.customizePrimaryColorRecommendations').removeClass('width270');
-      this.$el.find('.customizeSecondaryColorRecommendations').addClass('width270');
+      $customizeSecondaryColorRecommendations.addClass('width270');
       this.$el.find('.customizeBackgroundColorRecommendations').removeClass('width270');
       this.$el.find('.customizeTextColorRecommendations').removeClass('width270');
     }
@@ -1161,50 +1169,56 @@ module.exports = baseVw.extend({
 
   displayCustomizeBackgroundColor: function(e) {
     "use strict";
-    var secondaryColor = this.model.get('page').profile.secondary_color;
+    var $customizeBackgroundColorRecommendations = this.$el.find('.customizeBackgroundColorRecommendations'),
+        $customColorChoice = $customizeBackgroundColorRecommendations.find('.customColorChoice'),
+        secondaryColor = this.model.get('page').profile.secondary_color,
+        shades = [-0.70, -0.65, -0.55, -0.45, -0.35];
 
     $('#background_color').colpickHide();
 
-    if(this.$el.find('.customizeBackgroundColorRecommendations').hasClass('width270')){
-      this.$el.find('.customizeBackgroundColorRecommendations').removeClass('width270');
+    if($customizeBackgroundColorRecommendations.hasClass('width270')){
+      $customizeBackgroundColorRecommendations.removeClass('width270');
     }else{
       // set recommendations
-      this.$el.find('.customColorChoice').css('background','#fff'); // reset to white to give a cool transition
-      this.$el.find('.customizeBackgroundColorRecommendations .customColorChoice:first').css('background','transparent'); // set to transparent
-      this.$el.find('.customizeBackgroundColorRecommendations .customColorChoice:nth-child(2)').css('background', shadeColor2(secondaryColor, -0.70)); // 70% darker than primary_color
-      this.$el.find('.customizeBackgroundColorRecommendations .customColorChoice:nth-child(3)').css('background', shadeColor2(secondaryColor, -0.65)); // 65% darker than primary_color
-      this.$el.find('.customizeBackgroundColorRecommendations .customColorChoice:nth-child(4)').css('background', shadeColor2(secondaryColor, -0.55)); // 55% darker than primary_color
-      this.$el.find('.customizeBackgroundColorRecommendations .customColorChoice:nth-child(5)').css('background', shadeColor2(secondaryColor, -0.45)); // 45% darker than primary_color
-      this.$el.find('.customizeBackgroundColorRecommendations .customColorChoice:nth-child(6)').css('background', shadeColor2(secondaryColor, -0.35)); // 35% darker than primary_color
-      this.$el.find('.customizeBackgroundColorRecommendations .customColorChoice:last').css('background', shadeColor2(secondaryColor, -0.25)); // 25% darker than primary_color
+      $customColorChoice.css('background','#fff'); // reset to white to give a cool transition
+      $customColorChoice.first().css('background','transparent'); // set to transparent
+      
+      for (var i = 2; i <= 6; i++) {
+        $customColorChoice.eq(i).css('background', shadeColor2(secondaryColor, shades[i-2])); // 70% darker than primary_color
+      }
+
+      $customColorChoice.last().css('background', shadeColor2(secondaryColor, -0.25)); // 25% darker than primary_color
 
       // slide background_color recommendations out + hide others
       this.$el.find('.customizePrimaryColorRecommendations').removeClass('width270');
       this.$el.find('.customizeSecondaryColorRecommendations').removeClass('width270');
-      this.$el.find('.customizeBackgroundColorRecommendations').addClass('width270');
+      $customizeBackgroundColorRecommendations.addClass('width270');
       this.$el.find('.customizeTextColorRecommendations').removeClass('width270');
     }
   },
 
   displayCustomizeTextColor: function(e) {
     "use strict";
+    
+    var $customizeTextColorRecommendations = this.$el.find('.customizeTextColorRecommendations'),
+        $customColorChoice = $customizeTextColorRecommendations.find('.customColorChoice');
 
     $('#text_color').colpickHide();
 
-    if(this.$el.find('.customizeTextColorRecommendations').hasClass('width270')){
-      this.$el.find('.customizeTextColorRecommendations').removeClass('width270');
+    if($customizeTextColorRecommendations.hasClass('width270')){
+      $customizeTextColorRecommendations.removeClass('width270');
     }else{
       // set recommendations
-      this.$el.find('.customColorChoice').css('background','#fff');  // reset to white to give a cool transition
-      this.$el.find('.customizeTextColorRecommendations .customColorChoice:first').css('background','transparent'); // set to transparent
-      this.$el.find('.customizeTextColorRecommendations .customColorChoice:nth-child(2)').css('background', '#ffffff');
-      this.$el.find('.customizeTextColorRecommendations .customColorChoice:last').css('background', '#000000');
+      $customColorChoice.css('background','#fff');  // reset to white to give a cool transition
+      $customColorChoice.first().css('background','transparent'); // set to transparent
+      $customColorChoice.eq(2).css('background', '#ffffff');
+      $customColorChoice.last().css('background', '#000000');
 
       // slide background_color recommendations out + hide others
       this.$el.find('.customizePrimaryColorRecommendations').removeClass('width270');
       this.$el.find('.customizeSecondaryColorRecommendations').removeClass('width270');
       this.$el.find('.customizeBackgroundColorRecommendations').removeClass('width270');
-      this.$el.find('.customizeTextColorRecommendations').addClass('width270');
+      $customizeTextColorRecommendations.addClass('width270');
     }
   },
 


### PR DESCRIPTION
I did a little optimization of jQuery selectors.

Mostly changing `$('.parent .child')` to `$('.parent').find('.child')` which is [way faster](http://stackoverflow.com/a/18222210).

I also put some selectors into variables if they're used numerous times inside a method. That way jQuery doesn't have to access DOM every time it needs to use the element. 

I think we should stick to .find() in the future for the performance reasons. 
