### PR TITLE
Make close visible in purchase

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -6141,7 +6141,8 @@ input[type="checkbox"].fieldItem:checked + label .togLabelOff {
 #ov1.notFancy #userPage .js-modal-close [class *= "ion-"]:before,
 #ov1.notFancy #obContainer .js-modal-close [class *= "ion-"]:before,
 #ov1.notFancy #modalHolder .js-modal-close [class *= "ion-"]:before,
-#ov1.notFancy #messageModal .js-modal-close [class *= "ion-"]:before{
+#ov1.notFancy #messageModal .js-modal-close [class *= "ion-"]:before,
+#ov1 #modalHolder .js-closeBuyWizardModal [class *= "ion-"]:before {
   text-shadow: 0 0 1px rgba(0,0,0,1), 0 0 2px rgba(255,255,255, 1) !important;
 }
 


### PR DESCRIPTION
- includes the purchase close icon in the css rule to make the icon always visible regardless of the background color.
