### PR TITLE
fixing issue where the config form remains hidden on the server connect modal

### DIFF
--- a/js/views/serverConnectModal.js
+++ b/js/views/serverConnectModal.js
@@ -66,22 +66,6 @@ module.exports = BaseModal.extend({
       showNew: true
     });
 
-    setTimeout(() => {
-      if (this.isOpen()) {
-        // for some reason, when launching the modal and immediatally
-        // opening the config, a subsequent close doesn't position it
-        // properly unless we force a redraw (at least on Mac chrome).
-        this.$jsConfigFormWrap.one('transitionend', () => {
-          disp = this.$jsConfigFormWrap[0].style.display;
-          this.$jsConfigFormWrap[0].style.display = 'none';
-      
-          setTimeout(() => {
-            this.$jsConfigFormWrap[0].style.display = disp;
-          }, 100);      
-        });
-      }
-    }, 0);
-
     return this;
   },  
 


### PR DESCRIPTION
https://github.com/OpenBazaar/OpenBazaar-Client/issues/1516

This was a really edge case that I was only able to reproduce by trying to connect and edit a whole lot of different connection in rapid succession. Anyhow, there had been some code in place to force a re-draw of the config menu since in a certain case, its positioning was dramatically off until a re-paint. This re-paint code was somehow leaving the form with an inline display of 'none', even though a subsequent timeout should have reset it. Anyhow, looks like the forced re-paint isn't even needed anymore and removing it clears out this obscure bug.
