### PR TITLE
Check for updates every hour

### DIFF
--- a/main.js
+++ b/main.js
@@ -636,7 +636,7 @@ app.on('ready', function() {
 
   // Check for updates every hour
   autoUpdater.checkForUpdates();
-  setTimeout(function () {
+  setInterval(function () {
       autoUpdater.checkForUpdates();
   }, 3600000);
 

--- a/main.js
+++ b/main.js
@@ -633,7 +633,12 @@ app.on('ready', function() {
   var feedURL = 'http://updates.openbazaar.org:5000/update/' + platform + '/' + version;
   autoUpdater.setFeedURL(feedURL);
   mainWindow.webContents.executeJavaScript("console.log('Checking for new versions at " + feedURL + " ...')");
+
+  // Check for updates every hour
   autoUpdater.checkForUpdates();
+  setTimeout(function () {
+      autoUpdater.checkForUpdates();
+  }, 3600000);
 
 });
 


### PR DESCRIPTION
Right now the app only checks for updates on startup. This will periodically check every hour for updates and prompt to update. This should result in more up to date clients who don't restart their app.
