### PR TITLE
1450

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -1039,11 +1039,18 @@ label.fieldItem {
   height: 100%;
   top: 0;
   left: 0;
-  right: 0;
-  /* use fadeIn and fadeOut to change opacity */
-  transition: opacity .05s cubic-bezier(0, 0, 0.2, 1);
+  transition: opacity .05s cubic-bezier(0, 0, 0.2, 1),
+              width 0.5s ease;
   padding-top: 25px;
   z-index: 1;
+}
+
+#ov1.chatLoaded .modal:not(.modal-cover-fullscreen) {
+  width: calc(100% - 45px);
+}
+
+#ov1.chatOpen .modal:not(.modal-cover-fullscreen) {
+  width: calc(100% - 230px);
 }
 
 .modal.modal-navOffset {
@@ -1072,11 +1079,6 @@ label.fieldItem {
 .modal-opaque .modal-child {
   height: 574px;
 }
-
-#ov1.chatOpen .modal-child {
-  right: 230px;
-}
-
 
 .modal.modal-navOffset .modal-child {
   margin-top: 25px;

--- a/css/obBase.css
+++ b/css/obBase.css
@@ -1478,6 +1478,10 @@ h5 {
   top: 50px;
 }
 
+.modal-cover-fullscreen.modal.modal-navOffset .modal-childMain {
+  top: 0;
+}
+
 .modal-childMain {
   border-radius: 3px;
   background-color: #327eb8;

--- a/css/obBase.css
+++ b/css/obBase.css
@@ -3793,10 +3793,6 @@ input[type="checkbox"].fieldItem:checked + label .togLabelOff {
   padding-top: 1px;
 }
 
-#ov1.chatOpen .spinner-with-logo {
-  left: calc(50% - 115.5px);
-}
-
 .spinnerWrapper {
   transition: opacity 1s;
 }
@@ -4642,10 +4638,6 @@ input[type="checkbox"].fieldItem:checked + label .togLabelOff {
   margin-right: auto;
   text-align: center;
   transition: transform 0.5s ease;
-}
-
-#ov1.chatOpen .page-connect-modal .content {
-  transform: translateX(-115.5px);
 }
 
 .page-connect-modal .content .btn {

--- a/index.html
+++ b/index.html
@@ -42,8 +42,7 @@
   </div>
   <div id="statusBar"></div>
   <div id="pageNav" class="bar navBar navBar-main custCol-secondary padding0"></div>
-  <!-- the loading modal must be on top of the page nav or the reload button is hidden -->
-  <div id="loadingModal" class="modal modal-opaque js-loadingModal top0 hide">
+  <div id="loadingModal" class="modal modal-opaque modal-cover-fullscreen js-loadingModal hide">
     <div class="spinner-with-logo fullCentered">
       <i class="ion-android-sync spinner fontSize30 spinner-with-logo-icon"></i>
     </div>

--- a/js/start.js
+++ b/js/start.js
@@ -384,8 +384,7 @@ var loadProfile = function(landingRoute, onboarded) {
               });
 
               $('#sideBar').html(app.chatVw.render().el);
-
-              $('html').addClass('chatLoaded navBarLoaded');
+              $('html').addClass('chatLoaded');
 
               app.router = new router({userModel: user, userProfile: userProfile, socketView: newSocketView});
 

--- a/js/start.js
+++ b/js/start.js
@@ -385,6 +385,8 @@ var loadProfile = function(landingRoute, onboarded) {
 
               $('#sideBar').html(app.chatVw.render().el);
 
+              $('html').addClass('chatLoaded navBarLoaded');
+
               app.router = new router({userModel: user, userProfile: userProfile, socketView: newSocketView});
 
               if (externalRoute) {

--- a/js/views/chatVw.js
+++ b/js/views/chatVw.js
@@ -204,7 +204,6 @@ module.exports = baseVw.extend({
     this.slideOut();
 
     // mark as read
-    // $.post(app.serverConfigs.getActive().getServerBaseUrl() + '/mark_chat_message_as_read', { guid: model.get('guid') });
     this.markConvoAsRead(model.get('guid'));
 
     // mark as read on chat head


### PR DESCRIPTION
https://github.com/OpenBazaar/OpenBazaar-Client/issues/1450
- once the chat app is loaded, modals will, by default not cover chat.
- if you would like to completely cover the screen, both nav bar and chat, add the `modal-cover-fullscreen` class to the modal.

I don't think we need the scenario outlined below, but for giggles...
- if you would like to cover chat, but not the nav bar, add both the `modal-cover-fullscreen` & `modal-navOffset` classes, making sure the latter is declared second.
