### PR TITLE
Send Debug Email from Icon

### DIFF
--- a/main.js
+++ b/main.js
@@ -541,7 +541,7 @@ app.on('ready', function() {
     },
     {type: 'separator'},
     {label: 'View Debug Log', type: 'normal', click: function() {
-      var debugPath = serverPath + path.sep + 'debug.txt';
+      var debugPath = serverPath + 'debug.txt';
 
       fs.writeFile(debugPath, serverOut, (err) => {
         if (err) {
@@ -551,6 +551,19 @@ app.on('ready', function() {
         
         require('open')(debugPath);
       });
+    }},
+    {label: 'Send Debug Package', type: 'normal', click: function() {
+      var body = 'OpenBazaar Debug Report\n\n';
+      body += 'OS: ' + os.platform() + ' ' + os.release() + '\n';
+      body += 'Architecture: ' + os.arch() + '\n';
+      body += 'CPUs: ' + JSON.stringify(os.cpus(), null, 2) + '\n';
+      body += 'Free Memory: ' + os.freemem() + '\n';
+      body += 'Total Memory: ' + os.totalmem() + '\n\n';
+      body += 'Debug Log:\n';
+      body += serverOut;
+
+      require('open')('mailto:project@openbazaar.org?subject=OpenBazaar Debug Report&body=' + body);
+
     }},
     {type: 'separator'},
     {


### PR DESCRIPTION
This adds a menu item to the Tray Icons called Send Debug Package that collects system info and the debug log and fires up an email to send out for diagnostic assistance.

![image](https://cloud.githubusercontent.com/assets/45482/15371807/4d1c717e-1d0b-11e6-8af9-438aefb7837d.png)
