### PR TITLE
Fix tooltip length

### DIFF
--- a/js/templates/itemShort.html
+++ b/js/templates/itemShort.html
@@ -18,7 +18,7 @@ if(_.intersection(ob.userCountries, ob.ships_to).length > 0 || ob.ships_to == "A
         style="background-image: <% if(ob.avatar_hash && ob.avatarURL) { %> url(<%= ob.avatarURL %>), <% } %>url(imgs/defaultUser.png);"></div>
       <% } %>
       <div class="js-item pad8Left <% if(ob.title.length >= 30) { %>tooltip<% } %>"
-      <% if(ob.title.length >= 30) { %>data-tooltip="<%= ob.title.substring(0, 40) %>"<% } %> data-id="<%= ob.contract_hash %>">
+      <% if(ob.title.length >= 30) { %>data-tooltip="<%= ob.title %>"<% } %> data-id="<%= ob.contract_hash %>">
         <div class="textSize14px noOverflow textOpacity1 js-searchTitle">
           <%= ob.title %>
         </div>


### PR DESCRIPTION
Not sure what is the reason for truncating the tooltip text. I think the data should be fully visible (that's what tooltips are for). This PR fixes it.

![screen shot 2016-05-19 at 8 25 15 pm](https://cloud.githubusercontent.com/assets/3636406/15393548/876b0c5a-1e00-11e6-9093-50dad5586ed5.png)
