### PR TITLE
Tweaks

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -419,13 +419,6 @@ h6, .h6 {
   -webkit-app-region: no-drag;
 }
 
-#appBar .title {
-  /* since the loading spinners are centered in a manner
-     where chat is excluded from the width, we'll follow
-     suit here so our title is centered with the spinners */
-  width: calc(100% - 45px);
-}
-
 #pageNav .btn {
   -webkit-app-region: no-drag;
 }
@@ -4434,7 +4427,6 @@ input[type="checkbox"].fieldItem:checked + label .togLabelOff {
   left: 0;
   top: 50%;
   margin-top: 117px;
-  margin-left: -40px;
   opacity: 1;
   transition: opacity 1s 5s ease;
   box-sizing: border-box;

--- a/js/collections/ratingCl.js
+++ b/js/collections/ratingCl.js
@@ -17,6 +17,6 @@ module.exports = Backbone.Collection.extend({
       return [];
     }
 
-    return response;
+    return response.reverse();
   }
 });

--- a/js/router.js
+++ b/js/router.js
@@ -444,8 +444,6 @@ module.exports = Backbone.Router.extend({
   },
 
   settings: function(state){
-    $('.js-loadingModal').addClass('show');
-
     this.newView(settingsView, {
       viewArgs: {
         userModel: this.userModel,

--- a/js/views/homeVw.js
+++ b/js/views/homeVw.js
@@ -527,8 +527,9 @@ module.exports = pageVw.extend({
 
     //clear address bar
     window.obEventBus.trigger("setAddressBar", {'addressText': ""});
-    
+
     this.$el.find('.js-discoverHeading').html(window.polyglot.t('Discover'));
+    this.$el.find('.js-homeListingToggle').removeClass('hide');
 
     // change loading text copy
     this.$el.find('.js-loadingText').html(this.$el.find('.js-loadingText').data('defaultText'));

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -68,6 +68,8 @@ module.exports = pageVw.extend({
 
   initialize: function(options){
     var self = this;
+
+    $('.js-loadingModal').removeClass('hide');
     this.options = options || {};
     /* expected options:
      userModel
@@ -175,7 +177,6 @@ module.exports = pageVw.extend({
             getBTPrice("USD", function (btAve, currencyList) {
               self.availableCurrenciesList = currencyList;
               self.render();
-              $('.js-loadingModal').removeClass('show');
             });
           }
         });
@@ -183,6 +184,11 @@ module.exports = pageVw.extend({
       error: function(model, response){
         console.log(response);
         messageModal.show(window.polyglot.t('errorMessages.getError'), window.polyglot.t('errorMessages.userError'));
+      },
+      complete: function() {
+        if (!self.isRemoved()) {
+          $('.js-loadingModal').addClass('hide');
+        }
       }
     });
   },


### PR DESCRIPTION
- closes #1164 - Even though the ratings data doesn't have time information, AFAIK it is returning the result set in chronological order, so if we just reverse it, we have reverse chronological order. If we ever end up paginating the result set, then we'll need to rely on the server to do the sort, but until then, this should work.
- closes #1623 
- Shows loading spinner when navigating to the settings page while the page is fetching its initial data. This avoids the mostly blank screen that's in place during this time right now.
