### PR TITLE
multiple tweaks

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -743,6 +743,8 @@
     "newConfigTitle": "New Configuration",
     "new": "New"
   },
+  "langChangeRestartTitle": "Restart needed for language change",
+  "langChangeRestartMessage": "In order for your language change to fully take effect, you must restart the app.",
   "timezones": {
     "-12": "(GMT -12:00) Eniwetok, Kwajalein",
     "-11": "(GMT -11:00) Midway Island, Samoa",

--- a/js/router.js
+++ b/js/router.js
@@ -198,7 +198,7 @@ module.exports = Backbone.Router.extend({
     };
   },
 
-  newView: function(View, options, ignoreCache) {
+  newView: function(View, options) {
     var now = Date.now(),
         cached = this.viewCache[View.getCacheIndex(Backbone.history.getFragment())],
         requestedRoute = Backbone.history.getFragment(),
@@ -251,7 +251,7 @@ module.exports = Backbone.Router.extend({
       }
     }
 
-    if (cached && (now - cached.cachedAt < cached.view.cacheExpires && !ignoreCache)) {
+    if (cached && (now - cached.cachedAt < cached.view.cacheExpires)) {
       // we have an un-expired cached view, let's reattach it
       this.view = cached.view;
 
@@ -352,8 +352,6 @@ module.exports = Backbone.Router.extend({
   },
 
   home: function(state, searchText){
-    //if search terms have been given, don't use cached views
-    var ignoreCache = Boolean(searchText);
     this.newView(homeView, {
       viewArgs: {
         userModel: this.userModel,
@@ -362,7 +360,7 @@ module.exports = Backbone.Router.extend({
         state: state,
         searchItemsText: searchText
       }
-    }, ignoreCache);
+    });
 
     // hide the discover onboarding callout
     this.$discoverHolder = this.$discoverHolder || $('.js-OnboardingIntroDiscoverHolder');

--- a/js/start.js
+++ b/js/start.js
@@ -347,9 +347,16 @@ $(window).bind('keydown', function(e) {
 
     if (route !== null) {
       e.preventDefault();
-      Backbone.history.navigate(route, {
-        trigger: true
-      });
+
+      if (location.hash.startsWith('#' + route)) {
+        // Hard refresh if we're already on the page we're trying to route to
+        // so a cached page is not served.
+        app.router.refresh();
+      } else {
+        Backbone.history.navigate(route, {
+          trigger: true
+        });
+      }
     }
   }
 });
@@ -471,7 +478,19 @@ var loadProfile = function(landingRoute, onboarded) {
                 }).on('click-restart-now', () => {
                   location.reload();
                 }).render().open();
-              });              
+              });
+
+              // If navigating to a page you're already on, we'll hard refresh so
+              // a cached page is not served, which avoids the issue of it looking
+              // like nothing happened.
+              $(document).on('click', '[href^="#"]', (e) => {
+                var href = $(e.target).attr('href');
+
+                if (location.hash.startsWith(href)) {
+                  app.router.refresh();
+                  e.preventDefault();
+                }
+              });
 
               app.router = new router({userModel: user, userProfile: userProfile, socketView: newSocketView});
 

--- a/js/views/pageNavVw.js
+++ b/js/views/pageNavVw.js
@@ -463,8 +463,14 @@ module.exports = baseVw.extend({
   },
 
   getUnreadNotifCount: function() {
-    return this.unreadNotifsViaSocket + this.notificationsCl.getUnreadCount() -
+    var count;
+
+    count = this.unreadNotifsViaSocket + this.notificationsCl.getUnreadCount() -
       this.fetchNotifsMarkedAsRead || 0;
+
+    // fudge fix! sometimes the count is coming back as -1 and we can't reproduce it
+    // nor track down why, so we're reluctantly fudging it.
+    return count < 0 ? 0 : count;
   },
 
   onNotifMenuOpen: function() {

--- a/js/views/settingsVw.js
+++ b/js/views/settingsVw.js
@@ -674,7 +674,7 @@ module.exports = pageVw.extend({
   },
 
   cancelView: function(){
-    Backbone.history.loadUrl();
+    app.router.refresh();
   },
 
   themeClick: function(e) {


### PR DESCRIPTION
Achtung! This branch contains the unify-modals branch merged in because it depends on it. That is why the diff report for this guy looks so bloated. Once unify-modals is merged in, the diff report will be much more compact.
- closes #1689 
- fixes issue where the Settings page Reset buttons didn't appear to be working because they resulted in a cached page being loaded.
- adjusted functionality so discover searches do not uniformly ignore cache, rather if you attempt to navigate to a page you are already on, the app will "hard" refresh (i.e. delete the cache for that page and refresh with an uncached page).
- closes #1700 
