### PR TITLE
Add python debugging for failed startups

### DIFF
--- a/main.js
+++ b/main.js
@@ -161,6 +161,11 @@ var start_local_server = function() {
     });
     subpy.stderr.on('data', function (buf) {
       console.log('[STR] stderr "%s"', String(buf));
+      fs.appendFile(__dirname + path.sep + "python_error.log", String(buf), function(err) {
+          if(err) {
+              return console.log(err);
+          }
+      });
       stderr += buf;
     });
     subpy.on('error', function (err) {
@@ -173,6 +178,8 @@ var start_local_server = function() {
       serverRunning = false;
     });
     subpy.unref();
+  } else {
+    mainWindow.webContents.executeJavaScript("console.log('Unable to find OpenBazaar-Server at: '" + serverPath + "')");
   }
   if (fs.existsSync(__dirname + path.sep + '..' + path.sep + 'gpg')) {
        process.env.PATH = __dirname + path.sep + '..' + path.sep + 'gpg' + path.sep + 'pub' + path.sep + ';' + process.env.PATH;
@@ -550,6 +557,23 @@ app.on('ready', function() {
         
         require('open')(debugPath);
       });
+    }},
+    {label: 'Send Debug Package', type: 'normal', click: function() {
+      var body = 'OpenBazaar Debug Report\n\n';
+      body += 'OS: ' + os.platform() + ' ' + os.release() + '\n';
+      body += 'Architecture: ' + os.arch() + '\n';
+      body += 'CPUs: ' + JSON.stringify(os.cpus(), null, 2) + '\n';
+      body += 'Free Memory: ' + os.freemem() + '\n';
+      body += 'Total Memory: ' + os.totalmem() + '\n\n';
+      body += 'Debug Log:\n';
+      body += serverOut;
+
+      require('open')('mailto:project@openbazaar.org?subject=OpenBazaar Debug Report&body=' + body);
+
+    }},
+    {label: 'View Python Error Log', type: 'normal', click: function() {
+      var logPath = __dirname + path.sep + 'python_error.log';
+      require('open')(logPath);
     }},
     {label: 'Send Debug Package', type: 'normal', click: function() {
       var body = 'OpenBazaar Debug Report\n\n';

--- a/main.js
+++ b/main.js
@@ -188,7 +188,7 @@ var start_local_server = function() {
     });
     subpy.unref();
   } else {
-    mainWindow.webContents.executeJavaScript("console.log('Unable to find OpenBazaar-Server at: '" + serverPath + "')");
+    mainWindow && mainWindow.webContents.executeJavaScript("console.log('Unable to find OpenBazaar-Server at: '" + serverPath + "')");
   }
   if (fs.existsSync(__dirname + path.sep + '..' + path.sep + 'gpg')) {
        process.env.PATH = __dirname + path.sep + '..' + path.sep + 'gpg' + path.sep + 'pub' + path.sep + ';' + process.env.PATH;

--- a/main.js
+++ b/main.js
@@ -582,23 +582,10 @@ app.on('ready', function() {
 
   template.push(
     {
-      label: 'Send Debug Package', type: 'normal', click: function() {
-        var body = 'OpenBazaar Debug Report\n\n';
-        body += 'OS: ' + os.platform() + ' ' + os.release() + '\n';
-        body += 'Architecture: ' + os.arch() + '\n';
-        body += 'CPUs: ' + JSON.stringify(os.cpus(), null, 2) + '\n';
-        body += 'Free Memory: ' + os.freemem() + '\n';
-        body += 'Total Memory: ' + os.totalmem() + '\n\n';
-        body += 'Debug Log:\n';
-        body += serverOut;
-
-        require('open')('mailto:project@openbazaar.org?subject=OpenBazaar Debug Report&body=' + body);
-      }
+      type: 'separator'
     },
     {
-      type: 'separator' },
-      {
-        label: 'Quit', type: 'normal', accelerator: 'Command+Q', click: function () {
+      label: 'Quit', type: 'normal', accelerator: 'Command+Q', click: function () {
         app.quit();
       }
     }

--- a/main.js
+++ b/main.js
@@ -528,7 +528,7 @@ app.on('ready', function() {
   var osTrayIcon = 'openbazaar-mac-system-tray.png';
 
   trayMenu = new tray(__dirname + '/imgs/' + osTrayIcon);
-  var contextMenu = menu.buildFromTemplate([
+  var template = [
     {
       label: 'Start Local Server', type: 'normal', click: function () {
       start_local_server();
@@ -554,7 +554,7 @@ app.on('ready', function() {
           dialog.showErrorBox('Unable To Open Debug Log',
             'There was an error and we are unable to open the server debug log at this time.\n\n' + err);
         }
-        
+
         require('open')(debugPath);
       });
     }},
@@ -570,31 +570,41 @@ app.on('ready', function() {
 
       require('open')('mailto:project@openbazaar.org?subject=OpenBazaar Debug Report&body=' + body);
 
-    }},
-    {label: 'View Python Error Log', type: 'normal', click: function() {
+    }}
+  ];
+
+  if(launched_from_installer) {
+    template.push({label: 'View Python Error Log', type: 'normal', click: function() {
       var logPath = __dirname + path.sep + 'python_error.log';
       require('open')(logPath);
-    }},
-    {label: 'Send Debug Package', type: 'normal', click: function() {
-      var body = 'OpenBazaar Debug Report\n\n';
-      body += 'OS: ' + os.platform() + ' ' + os.release() + '\n';
-      body += 'Architecture: ' + os.arch() + '\n';
-      body += 'CPUs: ' + JSON.stringify(os.cpus(), null, 2) + '\n';
-      body += 'Free Memory: ' + os.freemem() + '\n';
-      body += 'Total Memory: ' + os.totalmem() + '\n\n';
-      body += 'Debug Log:\n';
-      body += serverOut;
+    }});
+  }
 
-      require('open')('mailto:project@openbazaar.org?subject=OpenBazaar Debug Report&body=' + body);
-
-    }},
-    {type: 'separator'},
+  template.push(
     {
-      label: 'Quit', type: 'normal', accelerator: 'Command+Q', click: function () {
-      app.quit();
+      label: 'Send Debug Package', type: 'normal', click: function() {
+        var body = 'OpenBazaar Debug Report\n\n';
+        body += 'OS: ' + os.platform() + ' ' + os.release() + '\n';
+        body += 'Architecture: ' + os.arch() + '\n';
+        body += 'CPUs: ' + JSON.stringify(os.cpus(), null, 2) + '\n';
+        body += 'Free Memory: ' + os.freemem() + '\n';
+        body += 'Total Memory: ' + os.totalmem() + '\n\n';
+        body += 'Debug Log:\n';
+        body += serverOut;
+
+        require('open')('mailto:project@openbazaar.org?subject=OpenBazaar Debug Report&body=' + body);
+      }
+    },
+    {
+      type: 'separator' },
+      {
+        label: 'Quit', type: 'normal', accelerator: 'Command+Q', click: function () {
+        app.quit();
+      }
     }
-    }
-  ]);
+  );
+
+  var contextMenu = menu.buildFromTemplate(template);
 
   trayMenu.setContextMenu(contextMenu);
 

--- a/main.js
+++ b/main.js
@@ -18,7 +18,8 @@ var fs = require('fs'),
     tray = require('tray'),
     ini = require('ini'),
     dialog = require('dialog'),
-    ipcMain = require('ipc-main');
+    ipcMain = require('ipc-main')
+    open = require('open');
 
 var launched_from_installer = false;
 var platform = os.platform();
@@ -560,7 +561,7 @@ app.on('ready', function() {
             'There was an error and we are unable to open the server debug log at this time.\n\n' + err);
         }
 
-        require('open')(debugPath);
+        open(debugPath);
       });
     }},
     {label: 'Send Debug Package', type: 'normal', click: function() {
@@ -573,7 +574,7 @@ app.on('ready', function() {
       body += 'Debug Log:\n';
       body += serverOut;
 
-      require('open')('mailto:project@openbazaar.org?subject=OpenBazaar Debug Report&body=' + body);
+      open('mailto:project@openbazaar.org?subject=OpenBazaar Debug Report&body=' + body);
 
     }}
   ];
@@ -581,7 +582,7 @@ app.on('ready', function() {
   if(launched_from_installer) {
     template.push({label: 'View Python Error Log', type: 'normal', click: function() {
       var logPath = __dirname + path.sep + 'python_error.log';
-      require('open')(logPath);
+      open(logPath);
     }});
   }
 

--- a/main.js
+++ b/main.js
@@ -30,6 +30,10 @@ var version = app.getVersion();
 var trayMenu = null;
 var subpy = null;
 
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is GCed.
+var mainWindow = null;
+
 var open_url = null; // This is for if someone opens a URL before the client is open
 
 if (argv.userData) {
@@ -203,10 +207,6 @@ ipcMain.on('activeServerChange', function(event, server) {
 
 // Report crashes to our server.
 //require('crash-reporter').start();
-
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the JavaScript object is GCed.
-var mainWindow = null;
 
 if (process.platform === "win32") {
   initWin32();

--- a/main.js
+++ b/main.js
@@ -174,6 +174,11 @@ var start_local_server = function() {
     });
     subpy.on('error', function (err) {
       console.log('Python error %s', String(err));
+      fs.appendFile(__dirname + path.sep + "python_error.log", String(err), function(error) {
+          if(error) {
+              return console.log(error);
+          }
+      });
     });
     subpy.on('close', function (code) {
       console.log('exited with ' + code);


### PR DESCRIPTION
If someone tries to startup an installer version of OpenBazaar and the python daemon fails to startup there will be no debug log to look at. This will dump the console output from the failed daemon startup to python_error.log and also provides a button to get it from the taskbar icon. This should help with troubleshooting apps that can't start the python for some reason.
