### PR TITLE
Clear Old Images When Making New Listing

### DIFF
--- a/js/models/itemMd.js
+++ b/js/models/itemMd.js
@@ -23,8 +23,6 @@ module.exports = window.Backbone.Model.extend({
     userCountry: "", //set by userPage View. This is a country code. This is used for editing.
     ownPage: false, //set by userPage View
     itemHash: "", //set by userPage View
-    combinedImagesArray: [], //tracks uploaded and old images
-    imageHashesToUpload: [],
     priceSet: 0, //set in Update Attribute below, so view can listen for it
 
     //the object below is just a reference for a typical response from the server.

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -663,5 +663,10 @@ module.exports = baseVw.extend({
     this.validateDescription();
 
     return this.$('#contractForm')[0].checkValidity();
+  },
+
+  remove: function() {
+    baseVw.prototype.remove.apply(this, arguments);
+    return this;
   }
 });

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -663,10 +663,5 @@ module.exports = baseVw.extend({
     this.validateDescription();
 
     return this.$('#contractForm')[0].checkValidity();
-  },
-
-  remove: function() {
-    baseVw.prototype.remove.apply(this, arguments);
-    return this;
   }
 });

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -1104,6 +1104,7 @@ UserPageVw = pageVw.extend({
       defaultItem.userCurrencyCode = self.options.userModel.get('currency_code');
       defaultItem.vendor_offer.listing.item.price_per_unit.fiat.currency_code =self.options.userModel.get('currency_code');
       defaultItem.vendor_offer.listing.id.guid = self.model.get('page').profile.guid;
+      defaultItem.vendor_offer.listing.item.image_hashes = [];
       this.itemEdit = new itemModel(defaultItem);
     }
     //add the moderator list to the item model


### PR DESCRIPTION
- when creating a second listing the model was picking up the image_hashes value from the previous listing. This clears it.
- the model should be a new model, how the image_hashes value was being carried over is unknown. There is probably a deeper issue somewhere.
