### PR TITLE
Closes gap where language could be set to a non-valid value.

### DIFF
--- a/js/models/userMd.js
+++ b/js/models/userMd.js
@@ -2,7 +2,6 @@
 
 var __ = require('underscore'),
     Backbone = require('backbone'),
-    languagesModel = require('../models/languagesMd'),
     countriesMd = require('./countriesMd'),
     saveToAPI = require('../utils/saveToAPI');
 
@@ -11,7 +10,6 @@ module.exports = Backbone.Model.extend({
   initialize: function(){
     this.countries = new countriesMd();
     this.countryArray = this.countries.get('countries');
-    this.languages = new languagesModel();
   },
 
   defaults: {

--- a/js/start.js
+++ b/js/start.js
@@ -61,7 +61,6 @@ var Polyglot = require('node-polyglot'),
     startUpRetry,
     removeStartupRetry,
     onActiveServerSync,
-    extendPolyglot,
     newPageNavView,
     newSocketView,
     startUpLoadingModal,
@@ -94,24 +93,15 @@ validateLanguage = function(lang){
   return "en-US"; //if language is not found, use English
 };
 
-//put language in the window so all templates and models can reach it. It's especially important in formatting currency.
-//retrieve the stored value, since user is a blank model at this point
-window.lang = validateLanguage(localStorage.getItem('lang'));
-
 //put polyglot in the window so all templates can reach it
 window.polyglot = new Polyglot();
 
-(extendPolyglot = function(lang) {
-  var language = require('./languages/' + lang + '.json');
-  window.polyglot.extend(language);
-})(window.lang);
-
-updatePolyglot = function(lang){
+(updatePolyglot = function(lang){
   lang = validateLanguage(lang);//make sure the language is valid
-  window.lang = lang;
-  extendPolyglot(lang);
+  window.lang = lang; //put language in the window so all templates and models can reach it. It's especially important in formatting currency.
   localStorage.setItem('lang', lang);
-};
+  window.polyglot.extend(require('./languages/' + lang + '.json'));
+})(validateLanguage(localStorage.getItem('lang')));
 
 user.on('change:language', function(md, lang) {
   // Re-starting the app on lang change. For now leaving in the code in various global views

--- a/js/start.js
+++ b/js/start.js
@@ -101,7 +101,7 @@ window.polyglot = new Polyglot();
   window.lang = lang; //put language in the window so all templates and models can reach it. It's especially important in formatting currency.
   localStorage.setItem('lang', lang);
   window.polyglot.extend(require('./languages/' + lang + '.json'));
-})(validateLanguage(localStorage.getItem('lang')));
+})(localStorage.getItem('lang'));
 
 user.on('change:language', function(md, lang) {
   // Re-starting the app on lang change. For now leaving in the code in various global views

--- a/js/start.js
+++ b/js/start.js
@@ -71,7 +71,8 @@ var Polyglot = require('node-polyglot'),
     setServerUrl,
     guidCreating,
     platformClass,
-    updatePolyglot;
+    updatePolyglot,
+    validateLanguage;
 
 if (process.platform === 'darwin') {
   platformClass = 'platform-mac';
@@ -85,23 +86,28 @@ if (process.platform === 'darwin') {
 
 $html.addClass(platformClass);
 
+validateLanguage = function(lang){
+  //check to see if the language exists in the language model
+  if (__.where(languages.get('languages'), {langCode: lang}).length) {
+    return lang;
+  }
+  return "en-US"; //if language is not found, use English
+};
+
 //put language in the window so all templates and models can reach it. It's especially important in formatting currency.
 //retrieve the stored value, since user is a blank model at this point
-window.lang = localStorage.getItem('lang') || "en-US";
+window.lang = validateLanguage(localStorage.getItem('lang'));
 
 //put polyglot in the window so all templates can reach it
-window.polyglot = new Polyglot({locale: window.lang});
+window.polyglot = new Polyglot();
 
-(extendPolyglot = function() {
-  // Make sure the language exists in the languages model
-  if (__.where(languages.get('languages'), {langCode: window.lang}).length) {
-    var language = require('./languages/' + window.lang + '.json');
-
-    window.polyglot.extend(language);
-  }
+(extendPolyglot = function(lang) {
+  var language = require('./languages/' + lang + '.json');
+  window.polyglot.extend(language);
 })(window.lang);
 
 updatePolyglot = function(lang){
+  lang = validateLanguage(lang);//make sure the language is valid
   window.lang = lang;
   extendPolyglot(lang);
   localStorage.setItem('lang', lang);


### PR DESCRIPTION
This will set the language to "en-US" if an invalid value is given to the updatePolyglot function. Previously if the language wasn't found, polyglot wasn't set to use any language.

This also removed the language model from the user model, since it wasn't being used any more.

This may solve #1733.
