### PR TITLE
Shipping Origin Can Be Set Per Listing

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -127,6 +127,7 @@
   "ReturnsPolicy": "Returns Policy",
   "Tags": "Tags",
   "Keywords": "Keywords",
+  "ShipsFrom": "Ships From",
   "ShipsFrom2": "Ships From %{country}",
   "ShipsTo": "Ships To",
   "ShipsTo2": "Ships To %{country}",

--- a/js/templates/itemEdit.html
+++ b/js/templates/itemEdit.html
@@ -50,7 +50,6 @@
 </form>
 
 <form id="contractForm">
-  <input type="text" name="shipping_origin" id="inputShippingOrigin" class="hide" />
   <div class="flexRow border0 marginBottom50">
     <div class="flexRow flexExpand">
       <div class="flexCol-7 pad15 flex-border">
@@ -234,6 +233,21 @@
                       <option value="ALL"><%= polyglot.t('AllRegions') %></option>
                       <option value="EUROPEAN_UNION"><%= polyglot.t('EuropeanUnion') %></option>
                       <option value="EUROPEAN_ECONOMIC_AREA"><%= polyglot.t('EuropeanEconomicArea') %></option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="flexRow custCol-border js-shippingRow">
+              <div class="flexCol-4 borderRight custCol-border">
+                <div class="fieldItem">
+                  <label for="shipsFrom"><%= polyglot.t('ShipsFrom') %></label>
+                </div>
+              </div>
+              <div class="flexCol-8">
+                <div class="fieldItem padding0" data-label="<%= polyglot.t('ShipsFrom') %>">
+                  <div class="fieldItem-selectWrapper noIcon positionWrapper">
+                    <select name="shipping_origin" class="chosen custCol-text" id="shipsFrom" required>
                     </select>
                   </div>
                 </div>

--- a/js/views/itemEditVw.js
+++ b/js/views/itemEditVw.js
@@ -165,6 +165,17 @@ module.exports = baseVw.extend({
     var countries = new countriesModel();
     //make a copy of the countries array
     var countryList = countries.get('countries').slice(0);
+    let shipsFrom = this.$el.find('#shipsFrom');
+    __.each(countryList, function(countryFromList, i){
+      let content = !i ? countryFromList.name : window.polyglot.t(`countries.${countryFromList.dataName}`);
+
+      shipsFrom.append(
+          `<option value="${countryFromList.dataName}">${content}</option>`
+      );
+    });
+    //set to existing value, default to user's home country if no value is set
+    shipsFrom.val(this.model.get('vendor_offer').listing.shipping.shipping_origin || this.model.get('userCountry'));
+    //add the ALL option
     countryList.unshift({
       "name": window.polyglot.t('WorldwideShipping'),
       "dataName": "ALL",
@@ -554,7 +565,6 @@ module.exports = baseVw.extend({
 
     this.$el.find('#inputCurrencyCode').val(cCode);
     this.$el.find('#inputShippingCurrencyCode').val(cCode);
-    this.$el.find('#inputShippingOrigin').val(this.model.get('userCountry'));
     //convert number field to string field
     this.$el.find('#inputPrice').val(this.$el.find('#priceLocal').val());
     this.$el.find('#inputShippingDomestic').val(this.$el.find('#shippingPriceLocalLocal').val());


### PR DESCRIPTION
- the user can set their shipping_origin in each listing, instead of it always using their country from the Settings API
- the origin defaults to the user's country
