### PR TITLE
Fixes transaction filter being lost on socket update

### DIFF
--- a/js/templates/transactions.html
+++ b/js/templates/transactions.html
@@ -27,20 +27,16 @@
     <%= polyglot.t('Purchases') %>
     <span class="pill fontSize12 textOpacity75 marginLeft2 js-purchasesCount"></span>
   </a>
-  <% if(ob.page.vendor){ %>
-  <a class="btn btn-bar btn-tab custCol-secondary js-tab js-salesTab paddingRight18" data-tab="sales">
+  <a class="btn btn-bar btn-tab custCol-secondary js-tab js-salesTab paddingRight18 <% if(!ob.page.vendor){ %>hide<% } %>" data-tab="sales">
     <span class="ion-log-in fontSize11 marginRight2 textOpacity1"></span>
     <%= polyglot.t('Sales') %>
     <span class="pill fontSize12 textOpacity75 marginLeft2 js-salesCount"></span>
   </a>
-  <% } %>
-  <% if(ob.page.moderator){ %>
-  <a class="btn btn-bar btn-tab custCol-secondary js-tab js-casesTab paddingRight18" data-tab="cases">
+  <a class="btn btn-bar btn-tab custCol-secondary js-tab js-casesTab paddingRight18 <% if(!ob.page.moderator){ %>hide<% } %>" data-tab="cases">
     <span class="ion-briefcase fontSize11 marginRight2 textOpacity1"></span>
     <%= polyglot.t('Cases') %>
     <span class="pill fontSize12 textOpacity75 marginLeft2 js-casesCount"></span>
   </a>
-  <% } %>
   <div class="flexExpand marginRight10">
     <a class="btn btn-txt pull-right custCol-primary js-downloadCSV"><i class="ion-archive fontSize12"></i><%= polyglot.t('transactions.ExportCSV') %></a>
   </div>

--- a/js/views/transactionsVw.js
+++ b/js/views/transactionsVw.js
@@ -106,9 +106,7 @@ module.exports = pageVw.extend({
         self.renderTab("purchases");
         self.salesCol.fetch({
           success: function(){
-            if (self.model.get('page').vendor) {
-              self.renderTab("sales");
-            }
+            self.renderTab("sales");
             self.casesCol.fetch({
               success: function() {
                 self.renderTab("cases");
@@ -273,7 +271,6 @@ module.exports = pageVw.extend({
   },
 
   renderTab: function(tabName, filterBy){
-
     var self = this,
         tabCollection = this[tabName + "Col"],
         tabWrapper = this[tabName + "Wrapper"];
@@ -322,15 +319,18 @@ module.exports = pageVw.extend({
       self.addTransaction(model, tabWrapper, tabName);
     });
 
-    this.$el.find('.js-'+tabName+'Count').html(tabCollection.length);
+    this.$('.js-'+tabName+'Count').html(tabCollection.length);
 
-    this.$el.find('.js-' + tabName)
+    this.$('.js-' + tabName)
         .append(tabWrapper)
         .find('.js-unpaidCount').html(tabCollection.where({status: 0}).length)
         .end().find('.js-loadingMsg').addClass('hide');
 
     if (!tabCollection.length) {
-      this.$el.find('.js-' + tabName + ' .js-emptyMsg').removeClass('hide');
+      this.$('.js-' + tabName + ' .js-emptyMsg').removeClass('hide');
+    } else {
+      //if the tab is hidden because they have turned off their store or moderator status, but it has transactions, unhide it
+      this.$('.js-'+tabName+"Tab").removeClass('hide');
     }
 
     if (!tabWrapper.children().length){

--- a/js/views/transactionsVw.js
+++ b/js/views/transactionsVw.js
@@ -338,10 +338,8 @@ module.exports = pageVw.extend({
       this['searchTransactions_'+tabName] && this['searchTransactions_'+tabName].size() && this['searchTransactions_'+tabName].clear();
     } else {
       if (this['searchTransactions_'+tabName]){
-        if (!filterBy || filterBy == "all" || filterBy == "dateNewest" || filterBy == "dateOldest") {
-          //reindex the list with new elements
-          this['searchTransactions_'+tabName].reIndex();
-        } else {
+        this['searchTransactions_'+tabName].reIndex();
+        if (filterBy && filterBy != "all" && filterBy != "dateNewest" && filterBy != "dateOldest") {
           //re-filter the list with new elements
           this['searchTransactions_'+tabName].filter(function (item) {
             return item.values().js_searchStatusNum == filterBy;

--- a/js/views/transactionsVw.js
+++ b/js/views/transactionsVw.js
@@ -245,8 +245,9 @@ module.exports = pageVw.extend({
   transactionFilter: function(e){
     var searchBy = $(e.target).val();
 
+    this.filterBy = searchBy;
+
     if (searchBy == 'dateNewest' || searchBy == 'dateOldest'){
-      this.filterBy = searchBy;
       this.$('.js-'+this.state+' .search').val("");
       this.renderTab(this.state);
     } else if (searchBy != "all"){
@@ -318,11 +319,7 @@ module.exports = pageVw.extend({
       tabCollection.sort();
     }
     tabCollection.each(function(model){
-      if (!filterBy || filterBy == "all" || filterBy == "dateNewest" || filterBy == "dateOldest") {
-        self.addTransaction(model, tabWrapper, tabName);
-      } else if (filterBy && filterBy != "dateNewest" && filterBy != "dateOldest" && model.get('status') == filterBy) {
-        self.addTransaction(model, tabWrapper, tabName);
-      }
+      self.addTransaction(model, tabWrapper, tabName);
     });
 
     this.$el.find('.js-'+tabName+'Count').html(tabCollection.length);
@@ -341,7 +338,15 @@ module.exports = pageVw.extend({
       this['searchTransactions_'+tabName] && this['searchTransactions_'+tabName].size() && this['searchTransactions_'+tabName].clear();
     } else {
       if (this['searchTransactions_'+tabName]){
-        this['searchTransactions_'+tabName].reIndex();
+        if (!filterBy || filterBy == "all" || filterBy == "dateNewest" || filterBy == "dateOldest") {
+          //reindex the list with new elements
+          this['searchTransactions_'+tabName].reIndex();
+        } else {
+          //re-filter the list with new elements
+          this['searchTransactions_'+tabName].filter(function (item) {
+            return item.values().js_searchStatusNum == filterBy;
+          });
+        }
       } else {
         this['searchTransactions_'+tabName] = new window.List('transactions' + tabName.charAt(0).toUpperCase() + tabName.substr(1), {valueNames: ['js-searchOrderID', 'js-searchPrice', 'js-searchUser', 'js-searchStatus', 'js-searchTitle', 'js_searchStatusNum'], page: 1000});
       }


### PR DESCRIPTION
- sets filter value in all cases so it's available when the data is refreshed
- removes old code that only pushed transactions that matched the filter to the DOM, this was preventing the filter which uses List.js from working after new data arrived
- applies the List.js filter whenever the tab is rendered
- if a user has turned off their store or moderation, but still has transactions in those tabs, the tabs will now still be shown
