### PR TITLE
Show the connection modal if saving to settings fails in onboarding

### DIFF
--- a/js/views/onboardingModal.js
+++ b/js/views/onboardingModal.js
@@ -351,6 +351,10 @@ module.exports = baseModal.extend({
                 console.log(errorThrown);
               }
             });
+          } else {
+            console.log("Save to settings has failed. Reason: "+data.reason);
+            app.serverConnectModal.failConnection("canceled", app.serverConfigs.getActive())
+                .open();
           }
         },
         error: function(jqXHR, status, errorThrown){


### PR DESCRIPTION
This fixes the rare case where saving to the settings api while in onboarding fails, which traps the user in a loading screen with no way to get out.
