### PR TITLE
Fix Connection Modal Hidden by Loading Modal

### DIFF
--- a/css/obBase.css
+++ b/css/obBase.css
@@ -4449,6 +4449,10 @@ input[type="checkbox"].fieldItem:checked + label .togLabelOff {
   text-align: center;
 }
 
+#ov1 .server-connect-modal {
+  z-index: 10; /* slightly hacky way to resolve problems when loading modal is in front of the server connect modal*/
+}
+
 #ov1 .server-connect-modal .modal-child {
   height: 625px;
 }


### PR DESCRIPTION
Fixes edge case where the loading modal is in front of the connect modal when the login fails, which hides the connect modal.

@rmisio this is a css fix, I'm going to merge it since it can leave the user trapped if they mistype their password. If there's an easy way to fix the js so the loading modal doesn't stack on top of the config modal and hide it, that would be ideal.
