### PR TITLE
Remove the address list from the buy flow.

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -662,6 +662,7 @@
     "MustAddAddress": "You must add an address to ship to",
     "VendorShipsTo": "Ships to:",
     "DoesNotShipHere": "Does not ship here",
+    "NoShippableAddresses": "This item does not ship to any of your saved addresses.",
     "Send": "Send",
     "SendBTCtoAddress": "Send %{amount} BTC to %{recipient}",
     "OpenAddress": "Open in Local Wallet",

--- a/js/templates/buyAddresses.html
+++ b/js/templates/buyAddresses.html
@@ -1,13 +1,10 @@
+<% if(_.intersection(_.pluck(ob.user.shipping_addresses, 'country'), ob.vendor_offer.listing.shipping.shipping_regions).length < 1 && !ob.worldwide) { %>
 <div class="flexRow custCol-primary custCol-border">
-  <div class="rowItem padding10">
-    <div class="textSize14px txt-fade padding10">
-      <strong><%= polyglot.t('buyFlow.VendorShipsTo') %> </strong>
-      <span>
-        <%= ob.shipsToList %>
-      </span>
-    </div>
+  <div class="rowItem padding10 txt-center">
+    <strong><%= polyglot.t('buyFlow.NoShippableAddresses') %></strong>
   </div>
 </div>
+<% } %>
 <% _.each(ob.user.shipping_addresses, function(address, i){ %>
   <% if(address.city && address.country && address.displayCountry && address.name && address.postal_code && address.state && address.street) { %>
     <% if(ob.worldwide || ob.vendor_offer.listing.shipping.shipping_regions.indexOf(address.country) > -1){ %>

--- a/js/views/buyAddressesVw.js
+++ b/js/views/buyAddressesVw.js
@@ -3,8 +3,7 @@
 var __ = require('underscore'),
     $ = require('jquery'),
     loadTemplate = require('../utils/loadTemplate'),
-    baseVw = require('./baseVw'),
-    localize = require('../utils/localize');
+    baseVw = require('./baseVw');
 
 module.exports = baseVw.extend({
 
@@ -30,8 +29,7 @@ module.exports = baseVw.extend({
           loadedTemplate(
               __.extend({}, self.model.toJSON(), {
                 worldwide: self.worldwide,
-                selected: selected,
-                shipsToList: localize.localizeShippingRegions(self.shippingRegions)
+                selected: selected
               })
           )
       );


### PR DESCRIPTION
- does not show the shippable addresses in the address screen of the buy flow
- if none of the buyer's addresses are shippable, a message is shown
