### PR TITLE
Sanitize the listing and profile models.

### DIFF
--- a/js/models/itemMd.js
+++ b/js/models/itemMd.js
@@ -4,7 +4,8 @@ var __ = require('underscore'),
     getBTPrice = require('../utils/getBitcoinPrice'),
     app = require('../App').getApp(),
     countriesMd = require('./countriesMd'),
-    autolinker = require( '../utils/customLinker');
+    autolinker = require( '../utils/customLinker'),
+    sanitizeModel = require('../utils/sanitizeModel');
 
 module.exports = window.Backbone.Model.extend({
   defaults: {
@@ -108,6 +109,10 @@ module.exports = window.Backbone.Model.extend({
     //when vendor currency code is in bitcoins, the json returned is different. Put the value in the expected place so the templates don't break.
     //check to make sure a blank result wasn't returned from the server
     if (response.vendor_offer){
+
+      //sanitize html
+      response.vendor_offer = sanitizeModel(response.vendor_offer);
+
       if (response.vendor_offer.listing.item.price_per_unit.bitcoin){
         response.vendor_offer.listing.item.price_per_unit.fiat = {
           "price": response.vendor_offer.listing.item.price_per_unit.bitcoin,

--- a/js/models/itemShortMd.js
+++ b/js/models/itemShortMd.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var __ = require('underscore'),
-    Backbone = require('backbone'),
+var Backbone = require('backbone'),
     app = require('../App').getApp(),
     getBTPrice = require('../utils/getBitcoinPrice');
 
@@ -23,17 +22,11 @@ module.exports = Backbone.Model.extend({
     handle: 0,
     avatar_hash: "",
     priceSet: 0, //set in Update Attribute below, so view can listen for it
-    short_description: ""
   },
 
   initialize: function(){
     this.updateAttributes();
     //this.on('change', this.updateAttributes, this);
-  },
-
-  parse: function(response){
-    response.short_description = __.unescape(response.short_description);
-    return response;
   },
 
   updateAttributes: function(){
@@ -77,7 +70,5 @@ module.exports = Backbone.Model.extend({
     if (thumbnailHash === "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb" || thumbnailHash.length !== 40) {
       this.set('thumbnail_hash', "");
     }
-
-    this.set('short_description', this.get('short_description'));
   }
 });

--- a/js/models/userProfileMd.js
+++ b/js/models/userProfileMd.js
@@ -3,7 +3,8 @@
 var __ = require('underscore'),
     Backbone = require('backbone'),
     is = require('is_js'),
-    autolinker = require( '../utils/customLinker');
+    autolinker = require( '../utils/customLinker'),
+    sanitizeModel = require('../utils/sanitizeModel');
 
 module.exports = Backbone.Model.extend({
   defaults: {
@@ -66,6 +67,8 @@ module.exports = Backbone.Model.extend({
   parse: function(response) {
     //first check to make sure server sent data in the response. Sometimes it doesn't.
     if (response.profile){
+
+      response.profile = sanitizeModel(response.profile);
 
       //check if colors are in hex, if not convert. This assumes non-hex colors are numbers or strings of numbers.
       response.profile.background_color = response.profile.background_color === 0 || response.profile.background_color ? this.convertColor(response.profile.background_color) : "#063753";

--- a/js/models/userShortMd.js
+++ b/js/models/userShortMd.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var __ = require('underscore'),
-    Backbone = require('backbone');
+var Backbone = require('backbone'),
+    sanitizeModel = require('../utils/sanitizeModel');
 
 module.exports = Backbone.Model.extend({
   defaults: {
@@ -14,7 +14,7 @@ module.exports = Backbone.Model.extend({
   },
 
   parse: function(response){
-    response.short_description = __.unescape(response.short_description);
+    response.short_description = sanitizeModel(response.short_description);
     return response;
   }
 });

--- a/js/router.js
+++ b/js/router.js
@@ -402,17 +402,19 @@ module.exports = Backbone.Router.extend({
     processHandle = this.processHandle(handle).done((guid) => {
       var state,
           itemHash,
-          skipNSFWmodal;
+          skipNSFWmodal,
+          subPathString;
 
       subPath = subPath && subPath.slice(1).split('/');
       state = subPath && subPath[0] || null;
       itemHash = subPath && subPath[1] || null;
       skipNSFWmodal = subPath && subPath[2] || null;
+      subPathString = subPath.join('/');
 
       // we want this to happen after the launchPageConnectModal processes
       // the resolution of the promise, hence the timeout.
       setTimeout(() => {
-        this.navigate(`userPage/${guid}${subPath ? '/' + subPath : ''}`, { replace: true });
+        this.navigate(`userPage/${guid}${subPath ? '/' + subPathString : ''}`, { replace: true });
         this.userPage(guid, state, itemHash, skipNSFWmodal, '@' + handle);
       }, 0);
     });

--- a/js/router.js
+++ b/js/router.js
@@ -402,19 +402,17 @@ module.exports = Backbone.Router.extend({
     processHandle = this.processHandle(handle).done((guid) => {
       var state,
           itemHash,
-          skipNSFWmodal,
-          subPathString;
+          skipNSFWmodal;
 
       subPath = subPath && subPath.slice(1).split('/');
       state = subPath && subPath[0] || null;
       itemHash = subPath && subPath[1] || null;
       skipNSFWmodal = subPath && subPath[2] || null;
-      subPathString = subPath.join('/');
 
       // we want this to happen after the launchPageConnectModal processes
       // the resolution of the promise, hence the timeout.
       setTimeout(() => {
-        this.navigate(`userPage/${guid}${subPath ? '/' + subPathString : ''}`, { replace: true });
+        this.navigate(`userPage/${guid}${subPath ? '/' + subPath.join('/') : ''}`, { replace: true });
         this.userPage(guid, state, itemHash, skipNSFWmodal, '@' + handle);
       }, 0);
     });

--- a/js/templates/settings.html
+++ b/js/templates/settings.html
@@ -1051,7 +1051,7 @@
                        name="moderation_fee"
                        class="fieldItem custCol-text width70px floatLeft"
                        id="moderatorFeeInput"
-                       value="<%= ob.page.profile.moderation_fee.toFixed(2) %>" required/><div class="floatLeft marginLeft5 lineHeight51 fontWeight500 textOpacity75">%</div>
+                       value="<%= Number(ob.page.profile.moderation_fee).toFixed(2) %>" required/><div class="floatLeft marginLeft5 lineHeight51 fontWeight500 textOpacity75">%</div>
               </div>
             </div>
             <a class="btn btn-large js-saveModerator custCol-secondary pull-right marginRight15 marginTop15 marginBottom50 btn-secondary">

--- a/js/utils/sanitizeModel.js
+++ b/js/utils/sanitizeModel.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var sanitizeHTML = require('sanitize-html');
+
+function sanitize(rawHTML) {
+  var processedHTML = rawHTML;
+
+  var decodeHtml = function(html) { //turn encoded html into regular html
+    var txt = document.createElement("textarea");
+    txt.innerHTML = html;
+    return txt.value;
+  };
+
+  processedHTML = sanitizeHTML(decodeHtml(processedHTML), {
+    allowedTags: [ 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'u', 'ul', 'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'hr', 'br', 'img', 'blockquote', 'span' ],
+    allowedAttributes: {
+      'a': [ 'href', 'title', 'alt' ],
+      'img': [ 'src', 'style']
+    },
+    allowedSchemes: [ 'http', 'https', 'ftp', 'mailto', 'ob' ]
+  });
+
+  return processedHTML;
+}
+
+module.exports = function(modelObject) {
+
+  function sanitizeModelData (obj) {
+    Object.keys(obj).forEach(function (key) {
+      if (typeof obj[key] === 'object') {
+        return sanitizeModelData(obj[key]);
+      }
+      obj[key] = sanitize(obj[key]);
+    });
+  }
+  sanitizeModelData(modelObject);
+
+  return modelObject;
+};


### PR DESCRIPTION
- sanitized potentially dangerous html in the listing and profile models, in case someone is using a rogue client and the server doesn't clean the data.
- fixed a bug in settings where the moderation fee didn't work because it was a string after sanitation and the template didn't cast it as a number
- fixed a bug in the router where the path would use a comma instead of a slash because an array was being converted directly to a string.
- removed unused code for short_description in the itemShort model, the listings API does not return a short_description value.
