### PR TITLE
Set Handle in AppBar Title

### DIFF
--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -483,9 +483,10 @@ UserPageVw = pageVw.extend({
   },
 
   setState: function(state, hash, options) {
-    var currentAddress,
+    var currentGUID = this.model.get('page').profile.guid,
         addressState,
         currentHandle = this.model.get('page').profile.handle,
+        currentAddress,
         isItemType = false;
 
     options = options || {};
@@ -552,16 +553,15 @@ UserPageVw = pageVw.extend({
     } else {
       addressState = "/" + state;
     }
-    currentAddress = this.model.get('page').profile.guid + addressState;
-    currentHandle = currentHandle ? currentHandle + addressState : "";
+
+    currentAddress = currentHandle || currentGUID;
+    currentAddress += addressState;
     if (isItemType && hash) {
-      currentAddress += "/"+ hash;
-      currentHandle = currentHandle ? currentHandle += "/"+ hash : "";
-    } else if (addressState === "createStore"){
-      currentAddress = this.model.get('page').profile.guid;
+      currentAddress += "/" + hash;
     }
 
-    window.obEventBus.trigger("setAddressBar", {'addressText': currentAddress, 'handle': currentHandle});
+    window.obEventBus.trigger("setAddressBar", {'addressText': currentAddress});
+    currentHandle && app.appBar.setTitle(currentHandle);
   },
 
   setControls: function(state){

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -315,6 +315,7 @@ UserPageVw = pageVw.extend({
           // Handle was requested
           if (profile.handle) {
             window.obEventBus.trigger('handleObtained', profile);
+            app.appBar.setTitle(profile.handle);
           }
         } else {
           //model was returned as a blank object
@@ -483,8 +484,8 @@ UserPageVw = pageVw.extend({
   },
 
   setState: function(state, hash, options) {
-    var addressState,
-        currentHandle = this.model.get('page').profile.handle,
+    var currentHandle = this.model.get('page').profile.handle,
+        addressState,
         currentAddress;
 
     options = options || {};
@@ -552,7 +553,6 @@ UserPageVw = pageVw.extend({
     currentAddress += addressState;
 
     window.obEventBus.trigger("setAddressBar", {'addressText': currentAddress});
-    currentHandle && app.appBar.setTitle(currentHandle);
   },
 
   setControls: function(state){

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -483,11 +483,9 @@ UserPageVw = pageVw.extend({
   },
 
   setState: function(state, hash, options) {
-    var currentGUID = this.model.get('page').profile.guid,
-        addressState,
+    var addressState,
         currentHandle = this.model.get('page').profile.handle,
-        currentAddress,
-        isItemType = false;
+        currentAddress;
 
     options = options || {};
 
@@ -544,21 +542,14 @@ UserPageVw = pageVw.extend({
     }
 
     if (state == "listing" || state == "listingOld" || state == "listingNew") {
-      isItemType = true;
-    }
-
-    //set address bar
-    if (isItemType) {
       addressState = "/listing";
+      addressState = hash ? addressState + "/" + hash : addressState;
     } else {
       addressState = "/" + state;
     }
 
-    currentAddress = currentHandle || currentGUID;
+    currentAddress = currentHandle || this.model.get('page').profile.guid;
     currentAddress += addressState;
-    if (isItemType && hash) {
-      currentAddress += "/" + hash;
-    }
 
     window.obEventBus.trigger("setAddressBar", {'addressText': currentAddress});
     currentHandle && app.appBar.setTitle(currentHandle);


### PR DESCRIPTION
When userPageVw.js sets the handle in the address bar, also set it the appBar (ie: if the route uses the guid, and the handle is retreived by the user page).
- cleans up logic on address bar text
- if the handle exists, sets the app bar title to the title
- Closes #1794
