### PR TITLE
Fix quantity bug in spinner

### DIFF
--- a/js/templates/buyDetails.html
+++ b/js/templates/buyDetails.html
@@ -36,7 +36,7 @@
                  step="1"
                  min="1"
                  name="max_quantity"
-                 max="<%= ob.vendor_offer.listing.metadata.max_quantity %>"
+                 max="<%= ob.vendor_offer.listing.metadata.max_quantity || 999999%>"
                  class="fieldItem spinButtons js-buyWizardQuantity border1 custCol-border marginTop4"
                  value="1"/>
           <div class="numberSpinnerUp"></div>


### PR DESCRIPTION
Set a default for the max_quantity, so a new client doesn't set old products with no max_quantity to a max of zero in the number spinner code.