### PR TITLE
Makes sure a userPage/listing route can't be set without an item hash…

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -375,7 +375,7 @@ module.exports = Backbone.Router.extend({
       userModel: this.userModel,
       userProfile: this.userProfile,
       userID: userID,
-      state: state,
+      state: state === 'listing' && !itemHash ? 'store' : state,
       itemHash: itemHash,
       socketView: this.socketView,
       skipNSFWmodal: skipNSFWmodal

--- a/js/views/userPageVw.js
+++ b/js/views/userPageVw.js
@@ -499,7 +499,7 @@ UserPageVw = pageVw.extend({
 
     options = options || {};
 
-    if (state === "listing"){
+    if (state === "listing" && hash){
       //clear old templates
       this.$el.find('.js-list4').html("");
       this.tabClick(this.$el.find('.js-storeTab'), this.$el.find('.js-item'));
@@ -534,7 +534,7 @@ UserPageVw = pageVw.extend({
       }
       this.tabClick(this.$el.find(".js-" + state + "Tab"), this.$el.find(".js-" + state));
       this.addTabToHistory(state, options.replaceHistory);
-    } else if (state){
+    } else if (state && state !== 'listing'){
       this.tabClick(this.$el.find(".js-" + state + "Tab"), this.$el.find(".js-" + state));
     } else {
       //if no state was set


### PR DESCRIPTION
… (it's set to store instead).

- for redundancy, also checks for a hash in the setState function, so the state can't be set to listing from inside the view if there is no item hash.