### PR TITLE
Add share buttons using Duo Search

### DIFF
--- a/js/templates/item.html
+++ b/js/templates/item.html
@@ -164,6 +164,19 @@
 </div>
 
 <div class="flexRow border0">
+  <div lass="flexCol-12">
+    <div id="shareBar" class="marginLeft20">
+      Share via <a href="https://duosear.ch">Duo Search</a>:
+      <a class="marginRight10 marginLeft10" title="Twitter" href="https://twitter.com/intent/tweet?text=<%= ob.vendor_offer.listing.item.title %>&via=duosearch&hashtags=OpenBazaar&url=https://duosear.ch/<%= ob.vendor_offer.listing.id.blockchain_id || ob.vendor_offer.listing.id.guid %>/listing/<%= ob.itemHash %>"><span class="ion-social-twitter"></span></a>
+      <a class="marginRight10" title="Facebook" href="https://www.facebook.com/sharer/sharer.php?u=https://duosear.ch/<%= ob.vendor_offer.listing.id.blockchain_id || ob.vendor_offer.listing.id.guid %>/listing/<%= ob.itemHash %>"><span class="ion-social-facebook"></span></a>
+      <a class="marginRight10" title="Reddit" href="https://www.reddit.com/submit?url=https://duosear.ch/<%= ob.vendor_offer.listing.id.blockchain_id || ob.vendor_offer.listing.id.guid %>/listing/<%= ob.itemHash %>"><span class="ion-social-reddit"></span></a>
+
+    </div>
+  </div>
+</div>
+
+
+<div class="flexRow border0">
   <div class="flexCol-12">
     <div class="custCol-border marginBottom40 marginTop30">
       <div class="bar navBar barFlush navBar custCol-secondary height55">
@@ -269,4 +282,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This adds listing sharing buttons for Facebook, Twitter and Reddit via Duo Search.

Pinging @JustinDrake as well for feedback.

Looks like this:
![image](https://cloud.githubusercontent.com/assets/45482/21233918/ff6fd39e-c2be-11e6-87d2-70c907dc0fc2.png)

Also the Duo Search text is a link to their web site.